### PR TITLE
feat: force publish revision

### DIFF
--- a/components/moissonneur-bal/revision-item.js
+++ b/components/moissonneur-bal/revision-item.js
@@ -9,13 +9,15 @@ import Tooltip from '../tooltip'
 import {getFile} from '@/lib/api-moissonneur-bal'
 import {getCommune} from '@/lib/cog'
 
-const RevisionPublication = ({status, errorMessage}) => {
+const RevisionPublication = ({status, errorMessage, currentSourceName, currentClientName}) => {
   if (status === 'provided-by-other-client') {
-    return <Badge severity='info' noIcon>Publiée par un autre client</Badge>
+    const badge = <Badge severity='warning' noIcon>Publiée par un autre client</Badge>
+    return currentClientName ? <Tooltip text={`ID: ${currentClientName}`}>{badge}</Tooltip> : badge
   }
 
   if (status === 'provided-by-other-source') {
-    return <Badge severity='error' noIcon>Publiée par une autre source</Badge>
+    const badge = <Badge severity='error' noIcon>Publiée par une autre source</Badge>
+    return currentSourceName ? <Tooltip text={currentSourceName}>{badge}</Tooltip> : badge
   }
 
   if (status === 'published') {
@@ -38,16 +40,20 @@ RevisionPublication.propTypes = {
     'published',
     'error'
   ]).isRequired,
-  errorMessage: PropTypes.string
+  errorMessage: PropTypes.string,
+  currentSourceName: PropTypes.string,
+  currentClientName: PropTypes.string
 }
 
-const RevisionItem = ({codeCommune, fileId, nbRows, nbRowsWithErrors, publication}) => {
+const RevisionItem = ({codeCommune, fileId, nbRows, nbRowsWithErrors, publication, onForcePublishRevision, isForcePublishRevisionLoading}) => {
   const commune = getCommune(codeCommune)
 
   const downloadFile = async () => {
     const file = await getFile(fileId)
     Router.push(file.url)
   }
+
+  const displayForcePublishButton = publication.status === 'provided-by-other-source' || publication.status === 'provided-by-other-client'
 
   return (
     <tr>
@@ -74,6 +80,16 @@ const RevisionItem = ({codeCommune, fileId, nbRows, nbRowsWithErrors, publicatio
           </Button>
         )}
       </td>
+      <td className='fr-col fr-my-1v'>
+        {displayForcePublishButton && (
+          <Button
+            onClick={onForcePublishRevision}
+            disabled={isForcePublishRevisionLoading}
+          >
+            {isForcePublishRevisionLoading ? 'Publication...' : 'Forcer la publication'}
+          </Button>
+        )}
+      </td>
     </tr>
   )
 }
@@ -83,7 +99,9 @@ RevisionItem.propTypes = {
   nbRows: PropTypes.number.isRequired,
   nbRowsWithErrors: PropTypes.number.isRequired,
   publication: PropTypes.object.isRequired,
-  fileId: PropTypes.string
+  fileId: PropTypes.string,
+  onForcePublishRevision: PropTypes.func,
+  isForcePublishRevisionLoading: PropTypes.bool
 }
 
 export default RevisionItem

--- a/lib/api-moissonneur-bal.js
+++ b/lib/api-moissonneur-bal.js
@@ -87,3 +87,19 @@ export async function udpateSource(id, changes) {
   return result.json()
 }
 
+export async function publishRevision(id, body) {
+  const result = await fetch(`${PROXY_API_MOISSONNEUR_BAL}/revisions/${id}/publish`, {
+    method: 'POST',
+    headers: {
+      'content-type': 'application/json'
+    },
+    body: JSON.stringify(body)
+  })
+
+  if (!result.ok) {
+    const error = await result.json()
+    throw new Error(error.message)
+  }
+
+  return result.json()
+}

--- a/server/proxy-api-moissonneur-bal.js
+++ b/server/proxy-api-moissonneur-bal.js
@@ -33,6 +33,13 @@ async function updateSource(req, res) {
   forward(response, res)
 }
 
+async function publishRevision(req, res) {
+  const {revisionId} = req.params
+
+  const response = await client.post(`revisions/${revisionId}/publish`, {json: req.body})
+  forward(response, res)
+}
+
 const app = new express.Router()
 
 app.use(express.json())
@@ -40,5 +47,6 @@ app.use(express.json())
 // Sources
 app.post('/sources/:sourceId/harvest', w(harvestSource))
 app.put('/sources/:sourceId', w(updateSource))
+app.post('/revisions/:revisionId/publish', w(publishRevision))
 
 module.exports = app


### PR DESCRIPTION
Ajoute un bouton "Forcer la publication" dans les révisions par communes qui apparait si la révision est publiée depuis un autre client ou une autre source.