### PR TITLE
Gestion des publication nullissime

### DIFF
--- a/components/moissonneur-bal/revision-item.js
+++ b/components/moissonneur-bal/revision-item.js
@@ -31,6 +31,10 @@ const RevisionPublication = ({status, errorMessage, currentSourceName, currentCl
       </Tooltip>
     )
   }
+
+  return (
+    <Badge noIcon>Inconnu</Badge>
+  )
 }
 
 RevisionPublication.propTypes = {
@@ -39,7 +43,7 @@ RevisionPublication.propTypes = {
     'provided-by-other-source',
     'published',
     'error'
-  ]).isRequired,
+  ]),
   errorMessage: PropTypes.string,
   currentSourceName: PropTypes.string,
   currentClientName: PropTypes.string
@@ -53,7 +57,7 @@ const RevisionItem = ({codeCommune, fileId, nbRows, nbRowsWithErrors, publicatio
     Router.push(file.url)
   }
 
-  const displayForcePublishButton = publication.status === 'provided-by-other-source' || publication.status === 'provided-by-other-client'
+  const displayForcePublishButton = publication?.status === 'provided-by-other-source' || publication?.status === 'provided-by-other-client'
 
   return (
     <tr>
@@ -94,11 +98,15 @@ const RevisionItem = ({codeCommune, fileId, nbRows, nbRowsWithErrors, publicatio
   )
 }
 
+RevisionItem.default = {
+  publication: null
+}
+
 RevisionItem.propTypes = {
   codeCommune: PropTypes.string.isRequired,
   nbRows: PropTypes.number.isRequired,
   nbRowsWithErrors: PropTypes.number.isRequired,
-  publication: PropTypes.object.isRequired,
+  publication: PropTypes.object,
   fileId: PropTypes.string,
   onForcePublishRevision: PropTypes.func,
   isForcePublishRevisionLoading: PropTypes.bool

--- a/pages/moissonneur-bal/sources/index.js
+++ b/pages/moissonneur-bal/sources/index.js
@@ -218,16 +218,18 @@ MoissoneurBAL.propTypes = {
 async function getRevisionsWithPublicationData(sourceId) {
   const revisions = await getSourceCurrentRevisions(sourceId)
   const revisionsWithPublicationData = await Promise.all(revisions.map(async revision => {
-    if (revision.publication.status === 'provided-by-other-source') {
-      const currentSource = await getSource(revision.publication.currentSourceId)
-      revision.publication = {
-        ...revision.publication,
-        currentSourceName: currentSource.organization.name
-      }
-    } else if (revision.publication.status === 'provided-by-other-client') {
-      revision.publication = {
-        ...revision.publication,
-        currentClientName: revision.publication.currentClientId
+    if (revision.publication) {
+      if (revision.publication.status === 'provided-by-other-source') {
+        const currentSource = await getSource(revision.publication.currentSourceId)
+        revision.publication = {
+          ...revision.publication,
+          currentSourceName: currentSource.organization.name
+        }
+      } else if (revision.publication.status === 'provided-by-other-client') {
+        revision.publication = {
+          ...revision.publication,
+          currentClientName: revision.publication.currentClientId
+        }
       }
     }
 


### PR DESCRIPTION
## Contexte
Il arrive que certaine révision n'est pas de status de publication.


## Modification
Rend optionnel la `revision.publication` et affiche un statut `inconnu`.