### PR TITLE
Identifie les clients de l'API dépôt sur les révisions du moissonneur

### DIFF
--- a/components/moissonneur-bal/revision-item.js
+++ b/components/moissonneur-bal/revision-item.js
@@ -11,13 +11,19 @@ import {getCommune} from '@/lib/cog'
 
 const RevisionPublication = ({status, errorMessage, currentSourceName, currentClientName}) => {
   if (status === 'provided-by-other-client') {
-    const badge = <Badge severity='warning' noIcon>Publiée par un autre client</Badge>
-    return currentClientName ? <Tooltip text={`ID: ${currentClientName}`}>{badge}</Tooltip> : badge
+    return (
+      <Tooltip text={currentClientName || 'inconnu'}>
+        <Badge severity='warning' noIcon>Publiée par un autre client</Badge>
+      </Tooltip>
+    )
   }
 
   if (status === 'provided-by-other-source') {
-    const badge = <Badge severity='error' noIcon>Publiée par une autre source</Badge>
-    return currentSourceName ? <Tooltip text={currentSourceName}>{badge}</Tooltip> : badge
+    return (
+      <Tooltip text={currentSourceName || 'inconnue'}>
+        <Badge severity='error' noIcon>Publiée par une autre source</Badge>
+      </Tooltip>
+    )
   }
 
   if (status === 'published') {

--- a/pages/moissonneur-bal/sources/index.js
+++ b/pages/moissonneur-bal/sources/index.js
@@ -6,6 +6,7 @@ import Button from '@codegouvfr/react-dsfr/Button'
 import Alert from '@codegouvfr/react-dsfr/Alert'
 
 import {getSource, udpateSource, getSourceHarvests, harvestSource, getSourceCurrentRevisions, publishRevision} from '@/lib/api-moissonneur-bal'
+import {getClient} from '@/lib/api-depot'
 
 import {useUser} from '@/hooks/user'
 
@@ -226,9 +227,15 @@ async function getRevisionsWithPublicationData(sourceId) {
           currentSourceName: currentSource.organization.name
         }
       } else if (revision.publication.status === 'provided-by-other-client') {
+        let currentClientName = null
+        if (revision.publication.currentClientId) {
+          const currentClient = await getClient(revision.publication.currentClientId)
+          currentClientName = currentClient.nom
+        }
+
         revision.publication = {
           ...revision.publication,
-          currentClientName: revision.publication.currentClientId
+          currentClientName
         }
       }
     }


### PR DESCRIPTION
## Contexte
Jusqu'à maintenant, seul l'identifiant "legacy" des clients était enregistré dans la révision d'un moissonnage. Or cet identifiant ne permet pas de récupérer des informations sur le client, comme son nom par exemple.

L'évolution apportée par https://github.com/BaseAdresseNationale/moissonneur-bal/pull/62 permet désormais d'utiliser le nouvel identifiant des clients de l'api dépôt.

## Évolution
Affiche le nom de client au survol du label "Publié par un autre client". Si le client n'est pas renseigné alors le tooltip affichera "inconnu".