### PR TITLE
Correction du lien vers le formulaire de client de l'API dépôt de démonstration

### DIFF
--- a/pages/api-depot.js
+++ b/pages/api-depot.js
@@ -46,7 +46,8 @@ const APIDepot = () => {
                     <div className='fr-grid-row fr-grid-row--gutters fr-grid-row--right'>
                       <div className='fr-col-2'>
                         <Link passHref href={{
-                          pathname: '/api-depot/client/client-form?demo=1',
+                          pathname: '/api-depot/client/client-form',
+                          query: {demo: 1}
                         }}
                         >
                           <Button iconId='fr-icon-add-line'>


### PR DESCRIPTION
## Contexte
Le lien renvoi actuellement vers une 404, car l'URL n'est pas encodée.

