### PR TITLE
Mise à jour du dashboard de statistiques

### DIFF
--- a/components/dashboard/charts/creation-count.js
+++ b/components/dashboard/charts/creation-count.js
@@ -1,0 +1,118 @@
+/* eslint-disable unicorn/no-array-reduce */
+import {Chart} from 'react-chartjs-2'
+import PropTypes from 'prop-types'
+import {Chart as ChartJS, registerables} from 'chart.js'
+import {useMemo} from 'react'
+
+ChartJS.register(...registerables)
+
+const CreationCount = ({creationsResponse, interval}) => {
+  const data = useMemo(() => {
+    let labels = creationsResponse.map(({date}) => {
+      const [year, month, day] = date.split('-')
+      return (interval && interval > 20) ? `${month}/${year}` : `${day}/${month}/${year}`
+    })
+
+    if (interval) {
+      labels = labels.filter((_data, index) => index % interval === 0)
+    }
+
+    const balCreations = creationsResponse
+      .map(({date, createdBAL}) => {
+        const [year, month, day] = date.split('-')
+
+        return {
+          date: `${day}/${month}/${year}`,
+          value: Object.values(createdBAL).reduce((acc, creations) => {
+            const {published, draft, demo, readyToPublish} = creations
+
+            return {
+              published: acc.published + published,
+              draft: acc.draft + draft,
+              demo: acc.demo + demo,
+              readyToPublish: acc.readyToPublish + readyToPublish
+            }
+          }, {published: 0, draft: 0, demo: 0, readyToPublish: 0})
+        }
+      })
+
+    const data = labels.reduce((acc, cur) => {
+      acc.push({
+        balsPublished: balCreations
+          .filter(({date}) => date.includes(cur))
+          .reduce((a, {value}) => a + value.published, 0),
+        balsDraft: balCreations
+          .filter(({date}) => date.includes(cur))
+          .reduce((a, {value}) => a + value.draft, 0),
+        balsReadyToPublish: balCreations
+          .filter(({date}) => date.includes(cur))
+          .reduce((a, {value}) => a + value.readyToPublish, 0),
+        balsDemo: balCreations
+          .filter(({date}) => date.includes(cur))
+          .reduce((a, {value}) => a + value.demo, 0),
+      })
+
+      return acc
+    }, [])
+
+    return {
+      labels,
+      datasets: [
+        {
+          label: 'BAL créées en statut démo',
+          data: data.map(({balsDemo}) => balsDemo),
+          backgroundColor: '#9BD0F5',
+        },
+        {
+          label: 'BAL créées en statut brouillon',
+          data: data.map(({balsDraft}) => balsDraft),
+          backgroundColor: '#72B8E9',
+        },
+        {
+          label: 'BAL créées et prêtes à être publiées',
+          data: data.map(({balsReadyToPublish}) => balsReadyToPublish),
+          backgroundColor: '#4D9BD3',
+        },
+        {
+          label: 'BAL créées et publiées',
+          data: data.map(({balsPublished}) => balsPublished),
+          backgroundColor: '#0B6CB0',
+        },
+      ]
+    }
+  }, [creationsResponse, interval])
+
+  return (
+    <Chart
+      type='bar'
+      data={data}
+      options={{
+        responsive: true,
+        plugins: {
+          title: {
+            display: true,
+            text: 'Nombre de créations',
+            font: {
+              size: 18,
+            },
+          },
+        },
+        scales: {
+          x: {
+            stacked: true,
+          },
+          y: {
+            stacked: true
+          }
+        }
+      }}
+    />
+  )
+}
+
+CreationCount.propTypes = {
+  creationsResponse: PropTypes.array.isRequired,
+  interval: PropTypes.number,
+}
+
+export default CreationCount

--- a/components/dashboard/charts/publication-count.js
+++ b/components/dashboard/charts/publication-count.js
@@ -1,3 +1,4 @@
+/* eslint-disable unicorn/no-array-reduce */
 import {Chart} from 'react-chartjs-2'
 import PropTypes from 'prop-types'
 import {Chart as ChartJS, registerables} from 'chart.js'
@@ -5,40 +6,133 @@ import {useMemo} from 'react'
 
 ChartJS.register(...registerables)
 
-const PublicationCountChart = ({publicationsResponse}) => {
-  const data = useMemo(() => ({
-    labels: publicationsResponse.map(({date}) => {
+const PublicationCountChart = ({publicationsResponse, firstPublicationEvolutionResponse, interval}) => {
+  const data = useMemo(() => {
+    let labels = publicationsResponse.map(({date}) => {
       const [year, month, day] = date.split('-')
-      return `${day}/${month}/${year}`
-    }),
-    datasets: [
-      {
-        label: 'BAL publiées',
-        data: publicationsResponse.map(({publishedBAL}) => Object.values(publishedBAL).reduce((acc, numPublications) => acc + numPublications, 0)),
-        borderColor: '#36A2EB',
-        backgroundColor: '#9BD0F5',
+      return (interval && interval > 20) ? `${month}/${year}` : `${day}/${month}/${year}`
+    })
+
+    if (interval) {
+      labels = labels.filter((_data, index) => index % interval === 0)
+    }
+
+    const newBALPublication = firstPublicationEvolutionResponse.map(({date, totalCreations, viaMesAdresses, viaMoissonneur}, index) => {
+      const [year, month, day] = date.split('-')
+      if (index === 0) {
+        return {date: `${day}/${month}/${year}`, value: 0}
       }
-    ]
-  }), [publicationsResponse])
+
+      return {date: `${day}/${month}/${year}`, value: {
+        total: totalCreations - firstPublicationEvolutionResponse[index - 1].totalCreations,
+        viaMesAdresses: viaMesAdresses - firstPublicationEvolutionResponse[index - 1].viaMesAdresses,
+        viaMoissonneur: viaMoissonneur - firstPublicationEvolutionResponse[index - 1].viaMoissonneur,
+      }}
+    })
+
+    const allBALPublication = publicationsResponse
+      .map(({date, publishedBAL}) => {
+        const [year, month, day] = date.split('-')
+
+        return {
+          date: `${day}/${month}/${year}`,
+          value: Object.values(publishedBAL).reduce((acc, publications) => {
+            const {total, viaMesAdresses, viaMoissonneur} = publications
+
+            return {
+              total: acc.total + total,
+              viaMesAdresses: acc.viaMesAdresses + viaMesAdresses,
+              viaMoissonneur: acc.viaMoissonneur + viaMoissonneur
+            }
+          }, {total: 0, viaMesAdresses: 0, viaMoissonneur: 0})
+        }
+      })
+
+    const data = labels.reduce((acc, cur) => {
+      acc.push({
+        allBALViaMesAdresses: allBALPublication
+          .filter(({date}) => date.includes(cur))
+          .reduce((a, {value}) => a + value.viaMesAdresses, 0),
+        allBALViaMoissonneur: allBALPublication
+          .filter(({date}) => date.includes(cur))
+          .reduce((a, {value}) => a + value.viaMoissonneur, 0),
+        allBALViaOther: allBALPublication
+          .filter(({date}) => date.includes(cur))
+          .reduce((a, {value}) => a + (value.total - (value.viaMesAdresses + value.viaMoissonneur)), 0),
+        newBALViaMesAdresses: newBALPublication
+          .filter(({date}) => date.includes(cur))
+          .reduce((a, {value}) => a + value.viaMesAdresses, 0),
+        newBALViaMoissonneur: newBALPublication
+          .filter(({date}) => date.includes(cur))
+          .reduce((a, {value}) => a + value.viaMoissonneur, 0),
+        newBALViaOther: newBALPublication
+          .filter(({date}) => date.includes(cur))
+          .reduce((a, {value}) => a + (value.total - (value.viaMesAdresses + value.viaMoissonneur)), 0),
+      })
+
+      return acc
+    }, [])
+
+    return {
+      labels,
+      datasets: [
+        {
+          label: 'Nouvelles BAL publiées via un autre client',
+          data: data.map(({newBALViaOther}) => newBALViaOther),
+          backgroundColor: '#fbe2e6',
+        },
+        {
+          label: 'Nouvelles BAL publiées via Moissonneur',
+          data: data.map(({newBALViaMoissonneur}) => newBALViaMoissonneur),
+          backgroundColor: '#F7C4CC',
+        },
+        {
+          label: 'Nouvelles BAL publiées via Mes Adresses',
+          data: data.map(({newBALViaMesAdresses}) => newBALViaMesAdresses),
+          backgroundColor: '#EF9BA8',
+        },
+        {
+          label: 'BAL re-publiées via un autre client',
+          data: data.map(({allBALViaOther, newBALViaOther}) => allBALViaOther - newBALViaOther),
+          backgroundColor: '#9BD0F5',
+        },
+        {
+          label: 'BAL re-publiées via Moissonneur',
+          data: data.map(({allBALViaMoissonneur, newBALViaMoissonneur}) => allBALViaMoissonneur - newBALViaMoissonneur),
+          backgroundColor: '#72B8E9',
+        },
+        {
+          label: 'BAL re-publiées via Mes Adresses',
+          data: data.map(({allBALViaMesAdresses, newBALViaMesAdresses}) => allBALViaMesAdresses - newBALViaMesAdresses),
+          backgroundColor: '#4D9BD3',
+        },
+      ]
+    }
+  }, [publicationsResponse, firstPublicationEvolutionResponse, interval])
 
   return (
     <Chart
-      type='line'
+      type='bar'
       data={data}
       options={{
         responsive: true,
         plugins: {
-          legend: {
-            display: false,
-          },
           title: {
             display: true,
-            text: 'Nombre de publications par jours',
+            text: 'Nombre de publications',
             font: {
               size: 18,
             },
           },
         },
+        scales: {
+          x: {
+            stacked: true,
+          },
+          y: {
+            stacked: true
+          }
+        }
       }}
     />
   )
@@ -46,6 +140,8 @@ const PublicationCountChart = ({publicationsResponse}) => {
 
 PublicationCountChart.propTypes = {
   publicationsResponse: PropTypes.array.isRequired,
+  firstPublicationEvolutionResponse: PropTypes.array.isRequired,
+  interval: PropTypes.number,
 }
 
 export default PublicationCountChart

--- a/components/dashboard/charts/publications-per-department.js
+++ b/components/dashboard/charts/publications-per-department.js
@@ -19,7 +19,7 @@ const PublicationPerDepartmentChart = ({publicationsResponse}) => {
           acc
           + selectedCommunes.reduce(
             (selectedCommunesCount, codeCommunes) =>
-              selectedCommunesCount + publishedBAL[codeCommunes],
+              selectedCommunesCount + publishedBAL[codeCommunes].total,
             0
           )
         )

--- a/components/dashboard/index.js
+++ b/components/dashboard/index.js
@@ -4,6 +4,7 @@ import {useState} from 'react'
 import PublicationPerDepartmentChart from './charts/publications-per-department'
 import FirstPublicationEvolutionChart from './charts/first-publication-evolution'
 import PublicationCountChart from './charts/publication-count'
+import CreationCountChart from './charts/creation-count'
 import {useDashboardData} from '@/hooks/dashboard-data'
 
 export const defaultChartOptions = {
@@ -54,7 +55,12 @@ const DashboardContainer = styled.div`
     height: 500px;
   }
 `
-const timeLapseButtons = [
+const timeLapses = [
+  {
+    label: 'Année',
+    value: 365,
+    interval: 30
+  },
   {
     label: 'Mois',
     value: 30,
@@ -62,39 +68,38 @@ const timeLapseButtons = [
   {
     label: 'Semaine',
     value: 7,
-  },
-  {
-    label: 'Jour',
-    value: 0,
-  },
+  }
 ]
 
 const Dashboard = () => {
-  const [timeLapse, setTimeLapse] = useState(30)
-  const {dashboardData} = useDashboardData(timeLapse)
+  const [timeLapseIndex, setTimeLapseIndex] = useState(1)
+  const {dashboardData} = useDashboardData(timeLapses[timeLapseIndex].value)
 
   return (
     <DashboardContainer>
       <div className='dashboard-header'>
-        {timeLapseButtons.map(({label, value}) => (
+        {timeLapses.map(({label}, index) => (
           <Button
             key={label}
             type='button'
-            className={value === timeLapse ? 'active' : ''}
-            onClick={() => setTimeLapse(value)}
+            className={index === timeLapseIndex ? 'active' : ''}
+            onClick={() => setTimeLapseIndex(index)}
           >
             {label}
           </Button>
         ))}
       </div>
       <div className='chart-wrapper'>
-        <FirstPublicationEvolutionChart firstPublicationEvolutionResponse={dashboardData.firstPublicationEvolutionResponse} />
+        <FirstPublicationEvolutionChart firstPublicationEvolutionResponse={dashboardData.firstPublicationEvolutionResponse} interval={timeLapses[timeLapseIndex].interval} />
       </div>
       <div className='chart-wrapper'>
         <PublicationPerDepartmentChart publicationsResponse={dashboardData.publicationsResponse} />
       </div>
       <div className='chart-wrapper'>
-        <PublicationCountChart publicationsResponse={dashboardData.publicationsResponse} />
+        <PublicationCountChart publicationsResponse={dashboardData.publicationsResponse} firstPublicationEvolutionResponse={dashboardData.firstPublicationEvolutionResponse} interval={timeLapses[timeLapseIndex].interval} />
+      </div>
+      <div className='chart-wrapper'>
+        <CreationCountChart creationsResponse={dashboardData.creationsResponse} interval={timeLapses[timeLapseIndex].interval} />
       </div>
     </DashboardContainer>
   )

--- a/lib/api-mes-adresses.js
+++ b/lib/api-mes-adresses.js
@@ -27,3 +27,11 @@ export async function searchBasesLocales(query) {
 
   return res.json()
 }
+
+export async function getStatCreations({from, to}) {
+  const res = await fetch(`${NEXT_PUBLIC_API_MES_ADRESSES}/stats/creations?from=${from}&to=${to}`)
+
+  if (res.ok) {
+    return res.json()
+  }
+}


### PR DESCRIPTION
# Contexte 

Suite à la demande d'Oscar, nous mettons à jour le dashboard BAL Admin pour mettre davantage en avant les publications de nouvelles BAL ainsi que leur source du publication.

# Fonctionnalités 

- Suppression du filtrage par jour car peu d'intérêt
- Ajout du filtrage par année
- Premier graphique (Evolution du nombre de BAL publiées pour la première fois): Ajout d'un dataset sous forme de barres qui correspond au nombre de nouvelles BAL ajoutées. Donc la ligne bleue est le cumul de nouvelles BAL qui ne fera que grimper, les barres roses sont le nombre de nouvelles BAL par rapport à la période n-1.
- Troisième graphique (Nombre de publications) : Met en rapport le nombre de nouvelles publications (rose) avec le nombre de publications totales (bleu) par période et les sources de publication

<img width="1048" alt="Capture d’écran 2023-05-12 à 16 38 49" src="https://github.com/BaseAdresseNationale/bal-admin/assets/4552238/c47bf93b-dea9-415d-9a70-9e2c7a6a2540">
<img width="1078" alt="Capture d’écran 2023-05-12 à 11 34 31" src="https://github.com/BaseAdresseNationale/bal-admin/assets/4552238/14a6ac84-21eb-497b-ba36-4722380dc619">
<img width="1075" alt="Capture d’écran 2023-05-12 à 11 34 02" src="https://github.com/BaseAdresseNationale/bal-admin/assets/4552238/32767054-e8b3-4095-95a0-fd053ed69703">

PR back API dépôt : https://github.com/BaseAdresseNationale/api-depot/pull/88
