### PR TITLE
Fix bug url partenaire

### DIFF
--- a/components/partenaires-de-la-charte/partenaire-form.tsx
+++ b/components/partenaires-de-la-charte/partenaire-form.tsx
@@ -294,6 +294,7 @@ export const PartenaireForm = ({title, data, onSubmit, submitLabel, controls, is
               label='Lien vers la charte*'
               nativeInputProps={{
                 value: formData.charteURL,
+                type: 'url',
                 onChange: handleEdit('charteURL'),
                 required: true,
               }}
@@ -303,6 +304,7 @@ export const PartenaireForm = ({title, data, onSubmit, submitLabel, controls, is
             <Input
               label='Lien vers le site'
               nativeInputProps={{
+                type: 'url',
                 value: formData.link,
                 onChange: handleEdit('link')}}
             />
@@ -314,6 +316,7 @@ export const PartenaireForm = ({title, data, onSubmit, submitLabel, controls, is
                   label='Lien vers le témoignage'
                   nativeInputProps={{
                     value: formData.testimonyURL,
+                    type: 'url',
                     onChange: handleEdit('testimonyURL')}}
                 />
               </div>
@@ -322,6 +325,7 @@ export const PartenaireForm = ({title, data, onSubmit, submitLabel, controls, is
                   label='Lien vers la BAL'
                   nativeInputProps={{
                     value: formData.balURL,
+                    type: 'url',
                     onChange: handleEdit('balURL')}}
                 />
               </div>
@@ -332,6 +336,7 @@ export const PartenaireForm = ({title, data, onSubmit, submitLabel, controls, is
                 label='Lien vers le témoignage'
                 nativeInputProps={{
                   value: formData.testimonyURL,
+                  type: 'url',
                   onChange: handleEdit('testimonyURL')}}
               />
             </div>


### PR DESCRIPTION
## Context

Sur Adresse (https://adresse.data.gouv.fr/bases-locales/charte/organismes) certain liens de partenaire redirige vers une 404 de adresse
C'est parce qu'il manque le https:// au url que c'est redirigé en local

## Fonctionalité

Ajout du `type='url'` au champs url du formulaire d'édition des partenaire de la charte