### PR TITLE
fix: can publish revision in error

### DIFF
--- a/components/moissonneur-bal/revision-item.tsx
+++ b/components/moissonneur-bal/revision-item.tsx
@@ -33,6 +33,7 @@ const RevisionItem = ({
 
   const displayForcePublishButton =
     !revision.publication ||
+    revision.publication?.status === RevisionStatusMoissoneurEnum.ERROR ||
     revision.publication?.status ===
       RevisionStatusMoissoneurEnum.NOT_CONFIGURED ||
     revision.publication?.status ===

--- a/pages/moissonneur-bal/organizations/[id].tsx
+++ b/pages/moissonneur-bal/organizations/[id].tsx
@@ -117,6 +117,8 @@ const OrganizationPage = ({
                   <th scope="col">Title</th>
                   <th scope="col">Status</th>
                   <th scope="col">Date de mise à jour</th>
+                  <th scope="col">Erreur Moissonnage</th>
+                  <th scope="col">Erreur Revisions</th>
                   <th scope="col" />
                 </tr>
               </thead>


### PR DESCRIPTION
## CONTEXT

<img width="1371" alt="Capture d’écran 2024-10-07 à 17 02 14" src="https://github.com/user-attachments/assets/08fcef41-14c1-4d49-9d9f-83249adb09bc">

A cause des erreur 504 de de l'api-depot (du au S3) certaine révision du moissonneur ne passe pas.
Et ensuite comme le fichier ne change pas, le moissonneur n'essaie pas de republier le BAL

## FIX

Ajout du bouton `forcer la publication` pour les BAL dont le publication.status est en erreur