### PR TITLE
Update pages partenaires

### DIFF
--- a/components/partenaires-de-la-charte/partenaire-item.tsx
+++ b/components/partenaires-de-la-charte/partenaire-item.tsx
@@ -6,6 +6,20 @@ import {
   PartenaireDeLaCharte,
   PartenaireDeLaCharteTypeEnum,
 } from "../../server/lib/partenaire-de-la-charte/entity";
+import Tooltip from "@codegouvfr/react-dsfr/Tooltip";
+import styled from "styled-components";
+
+const StyledNotification = styled.span`
+  position: absolute;
+  top: -14px;
+  right: -7px;
+  background-color: red;
+  color: white;
+  border-radius: 50%;
+  padding: 2px 6px;
+  font-size: 0.8em;
+  line-height: normal;
+`;
 
 const getPartenaireTypeColor = (type: PartenaireDeLaCharteTypeEnum) => {
   switch (type) {
@@ -35,50 +49,77 @@ export const PartenaireItem = ({
   services,
   dataGouvOrganizationId,
   apiDepotClientId,
-}: PartenaireDeLaCharte) => (
-  <tr key={id}>
-    <td className="fr-col fr-my-1v">
-      <Badge severity={getPartenaireTypeColor(type)} noIcon>
+  reviews,
+}: PartenaireDeLaCharte) => {
+  const pendingReviewsCount = (reviews || []).filter(
+    ({ isEmailVerified, isPublished }) => isEmailVerified && !isPublished
+  ).length;
+
+  const badgeType =
+    pendingReviewsCount > 0 ? (
+      <Tooltip title={`${pendingReviewsCount} avis en attente de publication`}>
+        <Badge
+          severity={getPartenaireTypeColor(type)}
+          noIcon
+          style={{ position: "relative" }}
+        >
+          {type}
+          {pendingReviewsCount > 0 && (
+            <StyledNotification>{pendingReviewsCount}</StyledNotification>
+          )}
+        </Badge>
+      </Tooltip>
+    ) : (
+      <Badge
+        severity={getPartenaireTypeColor(type)}
+        noIcon
+        style={{ position: "relative" }}
+      >
         {type}
       </Badge>
-    </td>
-    <td className="fr-col fr-my-1v">{name}</td>
-    <td className="fr-col fr-my-1v">{getDate(signatureDate, createdAt)}</td>
-    <td className="fr-col fr-my-1v">
-      {services?.map((service) => (
-        <Badge
-          severity="info"
-          style={{ marginRight: 2, marginBottom: 2 }}
-          key={service}
+    );
+
+  return (
+    <tr key={id}>
+      <td className="fr-col fr-my-1v">{badgeType}</td>
+      <td className="fr-col fr-my-1v">{name}</td>
+      <td className="fr-col fr-my-1v">{getDate(signatureDate, createdAt)}</td>
+      <td className="fr-col fr-my-1v">
+        {services?.map((service) => (
+          <Badge
+            severity="info"
+            style={{ marginRight: 2, marginBottom: 2 }}
+            key={service}
+          >
+            {service}
+          </Badge>
+        ))}
+      </td>
+      <td className="fr-col fr-my-1v">
+        {dataGouvOrganizationId?.length > 0 && (
+          <Badge severity="info" noIcon>
+            {dataGouvOrganizationId?.length} organisation(s) moissonnée(s)
+          </Badge>
+        )}
+        {apiDepotClientId?.length > 0 && (
+          <Badge severity="new" noIcon>
+            {apiDepotClientId.length} Client(s) api-depot
+          </Badge>
+        )}
+      </td>
+      <td className="fr-col fr-my-1v">
+        <Link
+          legacyBehavior
+          passHref
+          href={{
+            pathname: `/partenaires-de-la-charte/${id}`,
+          }}
         >
-          {service}
-        </Badge>
-      ))}
-    </td>
-    <td className="fr-col fr-my-1v">
-      {dataGouvOrganizationId?.length > 0 && (
-        <Badge severity="info" noIcon>
-          {dataGouvOrganizationId?.length} organisation(s) moissonnée(s)
-        </Badge>
-      )}
-      {apiDepotClientId?.length > 0 && (
-        <Badge severity="new" noIcon>
-          {apiDepotClientId.length} Client(s) api-depot
-        </Badge>
-      )}
-    </td>
-    <td className="fr-col fr-my-1v">
-      <Link
-        legacyBehavior
-        passHref
-        href={{
-          pathname: `/partenaires-de-la-charte/${id}`,
-        }}
-      >
-        <Button iconId="fr-icon-arrow-right-line" iconPosition="right">
-          Consulter
-        </Button>
-      </Link>
-    </td>
-  </tr>
-);
+          <Button iconId="fr-icon-arrow-right-line" iconPosition="right">
+            Consulter
+          </Button>
+        </Link>
+      </td>
+    </tr>
+  );
+};

--- a/components/partenaires-de-la-charte/reviews/review-item.tsx
+++ b/components/partenaires-de-la-charte/reviews/review-item.tsx
@@ -3,8 +3,8 @@ import Button from "@codegouvfr/react-dsfr/Button";
 import { Review } from "server/lib/partenaire-de-la-charte/reviews/entity";
 
 interface ReviewItemProps {
-  review: Review;
-  onShowReview: (review: Review) => void;
+  review: Partial<Review>;
+  onShowReview: (review: Partial<Review>) => void;
 }
 
 const ReviewItem = ({ review, onShowReview }: ReviewItemProps) => (
@@ -16,7 +16,7 @@ const ReviewItem = ({ review, onShowReview }: ReviewItemProps) => (
       {review.isPublished ? (
         <Badge severity="success">Publié</Badge>
       ) : (
-        <Badge severity="warning">En attente de validation</Badge>
+        <Badge severity="warning">Non publié</Badge>
       )}
     </td>
     <td className="fr-col fr-my-1v">

--- a/components/partenaires-de-la-charte/reviews/review-item.tsx
+++ b/components/partenaires-de-la-charte/reviews/review-item.tsx
@@ -9,7 +9,6 @@ interface ReviewItemProps {
 
 const ReviewItem = ({ review, onShowReview }: ReviewItemProps) => (
   <tr>
-    <td className="fr-col fr-my-1v">{review.fullname}</td>
     <td className="fr-col fr-my-1v">{review.email}</td>
     <td className="fr-col fr-my-1v">{review.community}</td>
     <td className="fr-col fr-my-1v">{review.rating} / 5</td>

--- a/components/partenaires-de-la-charte/reviews/review-item.tsx
+++ b/components/partenaires-de-la-charte/reviews/review-item.tsx
@@ -1,0 +1,35 @@
+import Badge from "@codegouvfr/react-dsfr/Badge";
+import Button from "@codegouvfr/react-dsfr/Button";
+import { Review } from "server/lib/partenaire-de-la-charte/reviews/entity";
+
+interface ReviewItemProps {
+  review: Review;
+  onShowReview: (review: Review) => void;
+}
+
+const ReviewItem = ({ review, onShowReview }: ReviewItemProps) => (
+  <tr>
+    <td className="fr-col fr-my-1v">{review.fullname}</td>
+    <td className="fr-col fr-my-1v">{review.email}</td>
+    <td className="fr-col fr-my-1v">{review.community}</td>
+    <td className="fr-col fr-my-1v">{review.rating} / 5</td>
+    <td className="fr-col fr-my-1v">
+      {review.isPublished ? (
+        <Badge severity="success">Publié</Badge>
+      ) : (
+        <Badge severity="warning">En attente de validation</Badge>
+      )}
+    </td>
+    <td className="fr-col fr-my-1v">
+      <Button
+        onClick={() => onShowReview(review)}
+        iconId="fr-icon-arrow-right-line"
+        iconPosition="right"
+      >
+        Afficher
+      </Button>
+    </td>
+  </tr>
+);
+
+export default ReviewItem;

--- a/components/partenaires-de-la-charte/reviews/reviews-table.tsx
+++ b/components/partenaires-de-la-charte/reviews/reviews-table.tsx
@@ -1,0 +1,43 @@
+import ReviewItem from "./review-item";
+import { PartenaireDeLaCharte } from "../../../server/lib/partenaire-de-la-charte/entity";
+import { Review } from "server/lib/partenaire-de-la-charte/reviews/entity";
+
+interface ReviewsTableProps {
+  partenaireDeLaCharte: PartenaireDeLaCharte;
+  onShowReview: (review: Review) => void;
+}
+
+const ReviewsTable = ({
+  partenaireDeLaCharte,
+  onShowReview,
+}: ReviewsTableProps) => {
+  return (
+    <div className="fr-table">
+      <table>
+        <caption>Liste des avis</caption>
+        <thead>
+          <tr>
+            <th scope="col">Nom et prénom</th>
+            <th scope="col">Email</th>
+            <th scope="col">Commune/Collectivité</th>
+            <th scope="col">Note</th>
+            <th scope="col">Statut</th>
+            <th scope="col">Actions</th>
+          </tr>
+        </thead>
+
+        <tbody>
+          {partenaireDeLaCharte.reviews.map((review) => (
+            <ReviewItem
+              key={review.id}
+              review={review}
+              onShowReview={onShowReview}
+            />
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+};
+
+export default ReviewsTable;

--- a/components/partenaires-de-la-charte/reviews/reviews-table.tsx
+++ b/components/partenaires-de-la-charte/reviews/reviews-table.tsx
@@ -17,7 +17,6 @@ const ReviewsTable = ({
         <caption>Liste des avis</caption>
         <thead>
           <tr>
-            <th scope="col">Nom et prénom</th>
             <th scope="col">Email</th>
             <th scope="col">Commune/Collectivité</th>
             <th scope="col">Note</th>

--- a/lib/partenaires-de-la-charte.ts
+++ b/lib/partenaires-de-la-charte.ts
@@ -122,7 +122,7 @@ export async function updateReview(
   payload: Partial<Review>
 ): Promise<boolean> {
   const response = await fetch(
-    `${NEXT_PUBLIC_BAL_ADMIN_URL}/api/partenaires-de-la-charte/reviews/${id}`,
+    `${NEXT_PUBLIC_BAL_ADMIN_URL}/api/reviews/${id}`,
     {
       method: "PUT",
       headers: { "Content-Type": "application/json" },
@@ -136,7 +136,7 @@ export async function updateReview(
 
 export async function deleteReview(id: string): Promise<boolean> {
   const response = await fetch(
-    `${NEXT_PUBLIC_BAL_ADMIN_URL}/api/partenaires-de-la-charte/reviews/${id}`,
+    `${NEXT_PUBLIC_BAL_ADMIN_URL}/api/reviews/${id}`,
     {
       method: "DELETE",
     }

--- a/lib/partenaires-de-la-charte.ts
+++ b/lib/partenaires-de-la-charte.ts
@@ -24,16 +24,16 @@ export async function getPartenaireDeLaCharte(id: string, headers?: any) {
   return partenaireDeLaCharte as PartenaireDeLaCharte;
 }
 
-export async function getPartenairesDeLaCharte(): Promise<
-  PartenaireDeLaCharte[]
-> {
+export async function getPartenairesDeLaCharte(
+  headers?: any
+): Promise<PartenaireDeLaCharte[]> {
   const url = new URL(
     `${NEXT_PUBLIC_BAL_ADMIN_URL}/api/partenaires-de-la-charte/`
   );
   url.searchParams.append("withCandidates", "true");
   url.searchParams.append("withoutPictures", "true");
 
-  const response = await fetch(url);
+  const response = await fetch(url, { headers });
   const partenairesDeLaCharte = await processResponse(response);
 
   return partenairesDeLaCharte as PartenaireDeLaCharte[];

--- a/lib/partenaires-de-la-charte.ts
+++ b/lib/partenaires-de-la-charte.ts
@@ -1,5 +1,6 @@
 import { PartenaireDeLaCharteDTO } from "server/lib/partenaire-de-la-charte/dto";
 import { PartenaireDeLaCharte } from "../server/lib/partenaire-de-la-charte/entity";
+import { Review } from "server/lib/partenaire-de-la-charte/reviews/entity";
 
 const NEXT_PUBLIC_BAL_ADMIN_URL =
   process.env.NEXT_PUBLIC_BAL_ADMIN_URL || "http://localhost:3000";
@@ -13,9 +14,10 @@ async function processResponse(response) {
   return response.json();
 }
 
-export async function getPartenaireDeLaCharte(id: string) {
+export async function getPartenaireDeLaCharte(id: string, headers?: any) {
   const response = await fetch(
-    `${NEXT_PUBLIC_BAL_ADMIN_URL}/api/partenaires-de-la-charte/${id}`
+    `${NEXT_PUBLIC_BAL_ADMIN_URL}/api/partenaires-de-la-charte/${id}`,
+    { headers }
   );
   const partenaireDeLaCharte = await processResponse(response);
 
@@ -106,6 +108,35 @@ export async function updatePartenaireDeLaCharte(
 export async function deletePartenaireDeLaCharte(id: string): Promise<boolean> {
   const response = await fetch(
     `${NEXT_PUBLIC_BAL_ADMIN_URL}/api/partenaires-de-la-charte/${id}`,
+    {
+      method: "DELETE",
+    }
+  );
+  const isDeleted = await processResponse(response);
+
+  return isDeleted as boolean;
+}
+
+export async function updateReview(
+  id: string,
+  payload: Partial<Review>
+): Promise<boolean> {
+  const response = await fetch(
+    `${NEXT_PUBLIC_BAL_ADMIN_URL}/api/partenaires-de-la-charte/reviews/${id}`,
+    {
+      method: "PUT",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(payload),
+    }
+  );
+  const isUpdated = await processResponse(response);
+
+  return isUpdated as boolean;
+}
+
+export async function deleteReview(id: string): Promise<boolean> {
+  const response = await fetch(
+    `${NEXT_PUBLIC_BAL_ADMIN_URL}/api/partenaires-de-la-charte/reviews/${id}`,
     {
       method: "DELETE",
     }

--- a/migrations/1738941552098-partenaire_review.ts
+++ b/migrations/1738941552098-partenaire_review.ts
@@ -1,0 +1,27 @@
+import { MigrationInterface, QueryRunner } from "typeorm";
+
+export class PartenaireReview1738941552098 implements MigrationInterface {
+  name = "PartenaireReview1738941552098";
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `CREATE TABLE "reviews" ("id" character varying(24) NOT NULL, "partenaire_id" character varying(24) NOT NULL, "fullname" text NOT NULL, "community" text, "email" text NOT NULL, "is_anonymous" bool, "rating" int NOT NULL, "comment" text, "is_published" bool,"created_at" TIMESTAMP NOT NULL DEFAULT now(), "updated_at" TIMESTAMP NOT NULL DEFAULT now(), CONSTRAINT "PK_1cda06c31eec1c95b3365a9134f" PRIMARY KEY ("id"))`
+    );
+    await queryRunner.query(
+      `CREATE INDEX "IDX_partenaire_de_la_charte__id" ON "reviews" ("partenaire_id") `
+    );
+    await queryRunner.query(
+      `ALTER TABLE "reviews" ADD CONSTRAINT "FK_1f663d2c0e63c2b9794b6b91421" FOREIGN KEY ("partenaire_id") REFERENCES "partenaires_de_la_charte"("id") ON DELETE CASCADE ON UPDATE NO ACTION`
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "reviews" DROP CONSTRAINT "FK_1f663d2c0e63c2b9794b6b91421"`
+    );
+    await queryRunner.query(
+      `DROP INDEX "public"."IDX_partenaire_de_la_charte__id"`
+    );
+    await queryRunner.query(`DROP TABLE "reviews"`);
+  }
+}

--- a/migrations/1738941552098-partenaire_review.ts
+++ b/migrations/1738941552098-partenaire_review.ts
@@ -5,7 +5,7 @@ export class PartenaireReview1738941552098 implements MigrationInterface {
 
   public async up(queryRunner: QueryRunner): Promise<void> {
     await queryRunner.query(
-      `CREATE TABLE "reviews" ("id" character varying(24) NOT NULL, "partenaire_id" character varying(24) NOT NULL, "community" text NOT NULL, "email" text NOT NULL, "verification_token" text NOT NULL, "is_email_verified" bool NOT NULL DEFAULT FALSE, "is_anonymous" bool NOT NULL DEFAULT FALSE, "rating" int NOT NULL, "comment" text, "is_published" bool NOT NULL DEFAULT FALSE, "created_at" TIMESTAMP NOT NULL DEFAULT now(), "updated_at" TIMESTAMP NOT NULL DEFAULT now(), CONSTRAINT "PK_1cda06c31eec1c95b3365a9134f" PRIMARY KEY ("id"))`
+      `CREATE TABLE "reviews" ("id" character varying(24) NOT NULL, "partenaire_id" character varying(24) NOT NULL, "community" text NOT NULL, "email" text NOT NULL, "verification_token" text NOT NULL, "is_email_verified" bool NOT NULL DEFAULT FALSE, "is_anonymous" bool NOT NULL DEFAULT FALSE, "rating" int NOT NULL, "comment" text NOT NULL, "reply" text, "is_published" bool NOT NULL DEFAULT FALSE, "created_at" TIMESTAMP NOT NULL DEFAULT now(), "updated_at" TIMESTAMP NOT NULL DEFAULT now(), CONSTRAINT "PK_1cda06c31eec1c95b3365a9134f" PRIMARY KEY ("id"))`
     );
     await queryRunner.query(
       `CREATE INDEX "IDX_reviews_partenaire_id" ON "reviews" ("partenaire_id") `

--- a/migrations/1738941552098-partenaire_review.ts
+++ b/migrations/1738941552098-partenaire_review.ts
@@ -5,10 +5,10 @@ export class PartenaireReview1738941552098 implements MigrationInterface {
 
   public async up(queryRunner: QueryRunner): Promise<void> {
     await queryRunner.query(
-      `CREATE TABLE "reviews" ("id" character varying(24) NOT NULL, "partenaire_id" character varying(24) NOT NULL, "fullname" text NOT NULL, "community" text, "email" text NOT NULL, "is_anonymous" bool, "rating" int NOT NULL, "comment" text, "is_published" bool,"created_at" TIMESTAMP NOT NULL DEFAULT now(), "updated_at" TIMESTAMP NOT NULL DEFAULT now(), CONSTRAINT "PK_1cda06c31eec1c95b3365a9134f" PRIMARY KEY ("id"))`
+      `CREATE TABLE "reviews" ("id" character varying(24) NOT NULL, "partenaire_id" character varying(24) NOT NULL, "community" text NOT NULL, "email" text NOT NULL, "verification_token" text NOT NULL, "is_email_verified" bool NOT NULL DEFAULT FALSE, "is_anonymous" bool NOT NULL DEFAULT FALSE, "rating" int NOT NULL, "comment" text, "is_published" bool NOT NULL DEFAULT FALSE, "created_at" TIMESTAMP NOT NULL DEFAULT now(), "updated_at" TIMESTAMP NOT NULL DEFAULT now(), CONSTRAINT "PK_1cda06c31eec1c95b3365a9134f" PRIMARY KEY ("id"))`
     );
     await queryRunner.query(
-      `CREATE INDEX "IDX_partenaire_de_la_charte__id" ON "reviews" ("partenaire_id") `
+      `CREATE INDEX "IDX_reviews_partenaire_id" ON "reviews" ("partenaire_id") `
     );
     await queryRunner.query(
       `ALTER TABLE "reviews" ADD CONSTRAINT "FK_1f663d2c0e63c2b9794b6b91421" FOREIGN KEY ("partenaire_id") REFERENCES "partenaires_de_la_charte"("id") ON DELETE CASCADE ON UPDATE NO ACTION`
@@ -19,9 +19,7 @@ export class PartenaireReview1738941552098 implements MigrationInterface {
     await queryRunner.query(
       `ALTER TABLE "reviews" DROP CONSTRAINT "FK_1f663d2c0e63c2b9794b6b91421"`
     );
-    await queryRunner.query(
-      `DROP INDEX "public"."IDX_partenaire_de_la_charte__id"`
-    );
+    await queryRunner.query(`DROP INDEX "public"."IDX_reviews_partenaire_id"`);
     await queryRunner.query(`DROP TABLE "reviews"`);
   }
 }

--- a/pages/partenaires-de-la-charte/[id].tsx
+++ b/pages/partenaires-de-la-charte/[id].tsx
@@ -190,7 +190,7 @@ const PartenaireDeLaChartePage = ({
           onShowReview={handleShowReview}
         />
       )}
-      <reviewModale.Component title={`Avis de ${selectedReview?.fullname}`}>
+      <reviewModale.Component title={`Avis de ${selectedReview?.community}`}>
         {selectedReview && (
           <>
             <p>
@@ -202,11 +202,9 @@ const PartenaireDeLaChartePage = ({
             <p>
               Par{" "}
               <b>
-                {selectedReview.fullname} ({selectedReview.email}){" "}
-                {selectedReview.community
-                  ? `de ${selectedReview.community} `
-                  : ""}
-                {selectedReview.isAnonymous && "(anonyme)"}
+                {`${selectedReview.email} - ${selectedReview.community} ${
+                  selectedReview.isAnonymous ? "(anonyme)" : ""
+                }`}
               </b>
             </p>
             <p>

--- a/pages/partenaires-de-la-charte/[id].tsx
+++ b/pages/partenaires-de-la-charte/[id].tsx
@@ -16,6 +16,8 @@ import {
 import { PartenaireDeLaCharte } from "../../server/lib/partenaire-de-la-charte/entity";
 import ReviewsTable from "@/components/partenaires-de-la-charte/reviews/reviews-table";
 import { Review } from "server/lib/partenaire-de-la-charte/reviews/entity";
+import Input from "@codegouvfr/react-dsfr/Input";
+import Checkbox from "@codegouvfr/react-dsfr/Checkbox";
 
 type PartenaireDeLaChartePageProps = {
   partenaireDeLaCharte: PartenaireDeLaCharte;
@@ -51,6 +53,10 @@ const PartenaireDeLaChartePage = ({
     reviewModale.close();
   };
 
+  const handleEditReview = (key: string) => (e) => {
+    setSelectedReview((prev) => ({ ...prev, [key]: e.target.value }));
+  };
+
   const onUpdateReview = async () => {
     if (!selectedReview) {
       return;
@@ -58,23 +64,20 @@ const PartenaireDeLaChartePage = ({
 
     try {
       await updateReview(selectedReview.id, {
-        isPublished: !selectedReview.isPublished,
+        isPublished: selectedReview.isPublished,
+        reply: selectedReview.reply,
       });
-      const successMessage = selectedReview.isPublished
-        ? "Avis dé-publié"
-        : "Avis publié";
       const updatedPartenaireDeLaCharte = await getPartenaireDeLaCharte(
         partenaireDeLaCharte.id
       );
       setPartenaireDeLaCharte(updatedPartenaireDeLaCharte);
-      toast(successMessage, { type: "success" });
+      toast("Les modifications ont bien été enregistrées", { type: "success" });
       handleCloseReview();
     } catch (error: unknown) {
       console.error(error);
-      const errorMessage = selectedReview.isPublished
-        ? "Erreur lors de la dé-publication de l’avis"
-        : "Erreur lors de la publication de l’avis";
-      toast(errorMessage, { type: "error" });
+      toast("Une erreur est survenue lors de l'enregistrement", {
+        type: "error",
+      });
     }
   };
 
@@ -215,10 +218,32 @@ const PartenaireDeLaChartePage = ({
                 ? `Commentaire : ${selectedReview.comment}`
                 : ""}
             </p>
+            <Input
+              label="Réponse du prestataire"
+              textArea
+              nativeTextAreaProps={{
+                value: selectedReview.reply,
+                onChange: handleEditReview("reply"),
+              }}
+            />
+            <Checkbox
+              options={[
+                {
+                  label: "Publier cet avis",
+                  nativeInputProps: {
+                    checked: selectedReview.isPublished,
+                    onChange: () => {
+                      setSelectedReview((prev) => ({
+                        ...prev,
+                        isPublished: !prev.isPublished,
+                      }));
+                    },
+                  },
+                },
+              ]}
+            />
             <div>
-              <Button onClick={onUpdateReview}>
-                {selectedReview.isPublished ? "Dé-publier" : "Publier"}
-              </Button>
+              <Button onClick={onUpdateReview}>Enregistrer</Button>
               <Button
                 priority="secondary"
                 onClick={onDeleteReview}

--- a/pages/partenaires-de-la-charte/index.tsx
+++ b/pages/partenaires-de-la-charte/index.tsx
@@ -97,9 +97,12 @@ const PartenairesDeLaChartePage = ({
   </div>
 );
 
-export async function getServerSideProps({ query }) {
+export async function getServerSideProps({ query, ...context }) {
+  const cookies = context.req.headers.cookie;
   const { tab } = query;
-  const allPartenairesDeLaCharte = await getPartenairesDeLaCharte();
+  const allPartenairesDeLaCharte = await getPartenairesDeLaCharte({
+    cookie: cookies,
+  });
   const partenaires = allPartenairesDeLaCharte.filter((partenaireDeLaCharte) =>
     Boolean(partenaireDeLaCharte.signatureDate)
   );

--- a/server/index.ts
+++ b/server/index.ts
@@ -14,6 +14,7 @@ import ProxyMoissonneurBal from "./proxy/moissonneur-bal.proxy";
 import ProxyMesAdressesApi from "./proxy/mes-adresses-api.proxy";
 // CONTROLLER
 import PartenaireDeLaCharteController from "./lib/partenaire-de-la-charte/controller";
+import ReviewsController from "./lib/partenaire-de-la-charte/reviews/controller";
 import EventController from "./lib/events/controller";
 import BalWidgetController from "./lib/bal-widget/controller";
 import { Logger } from "./utils/logger.utils";
@@ -57,6 +58,7 @@ async function main() {
 
   // Some Partenaire de la charte routes are public, others are protected by routeGuard
   server.use("/api/partenaires-de-la-charte", PartenaireDeLaCharteController);
+  server.use("/api/reviews", ReviewsController);
   server.use("/api/events", EventController);
   server.use("/api/bal-widget", BalWidgetController);
 

--- a/server/is-admin.ts
+++ b/server/is-admin.ts
@@ -1,0 +1,21 @@
+import got from "got";
+
+export async function isAdmin(req, res, next) {
+  const nextAuthClient = got.extend({
+    prefixUrl: process.env.NEXTAUTH_URL,
+    headers: {
+      cookie: req.headers.cookie,
+    },
+    throwHttpErrors: false,
+    responseType: "json",
+  });
+
+  const response = await nextAuthClient.get("session");
+  const session: any = response.body;
+
+  if (session.user) {
+    req.isAdmin = true;
+  }
+
+  next();
+}

--- a/server/lib/mailer/email.templates.ts
+++ b/server/lib/mailer/email.templates.ts
@@ -2,6 +2,7 @@ import sanitizeHtml from "sanitize-html";
 import { getMailToCommuneTemplate } from "./mail-to-communes-template";
 import { Event } from "../events/entity";
 import { getMailToParticipantTemplate } from "./mail-to-participant-template";
+import { getEmailVerificationTemplate } from "./mail-to-email-verification-template";
 
 const Emails = {
   "candidature-partenaire-de-la-charte": {
@@ -49,6 +50,18 @@ const Emails = {
         endHour: sanitizeHtml(endHour),
         href: sanitizeHtml(href),
         instructions: sanitizeHtml(instructions),
+      }),
+    };
+  },
+  emailVerification: (verificationLink: string, to: string) => {
+    const subject = `Nous avons bien reçu votre avis`;
+    return {
+      from: process.env.SMTP_FROM || "adresse@data.gouv.fr",
+      to,
+      subject,
+      html: getEmailVerificationTemplate({
+        subject,
+        verificationLink,
       }),
     };
   },

--- a/server/lib/mailer/email.templates.ts
+++ b/server/lib/mailer/email.templates.ts
@@ -11,6 +11,13 @@ const Emails = {
     text: `Bonjour,\n\nUne nouvelle candidature aux partenaires de la charte a été soumise.\n\nVous pouvez la consulter sur <a href="${process.env.NEXT_PUBLIC_BAL_ADMIN_URL}/partenaires-de-la-charte?tab=candidatures">BAL Admin</a>.\n\nBonne journée,\n\nL’équipe BAL`,
     html: `<p>Bonjour,</p><p>Une nouvelle candidature aux partenaires de la charte a été soumise.</p><p>Vous pouvez la consulter sur <a href="${process.env.NEXT_PUBLIC_BAL_ADMIN_URL}/partenaires-de-la-charte?tab=candidatures">BAL Admin</a>.</p><p>Bonne journée,</p><p>L’équipe BAL</p>`,
   },
+  reviewReceived: ({ partenaireId }) => ({
+    from: process.env.SMTP_FROM || "adresse@data.gouv.fr",
+    to: "adresse@data.gouv.fr",
+    subject: "Un nouvel avis a été posté sur une société",
+    text: `Bonjour,\n\nUn nouvel avis sur une société référencée dans l'annuaire des prestataires vient d'être reçu.\n\nVous pouvez le consulter sur <a href="${process.env.NEXT_PUBLIC_BAL_ADMIN_URL}/partenaires-de-la-charte/${partenaireId}">BAL Admin</a>.\n\nBonne journée,\n\nL’équipe BAL`,
+    html: `<p>Bonjour,</p><p>Un nouvel avis sur une société référencée dans l'annuaire des prestataires vient d'être reçu.</p><p>Vous pouvez le consulter sur <a href="${process.env.NEXT_PUBLIC_BAL_ADMIN_URL}/partenaires-de-la-charte/${partenaireId}">BAL Admin</a>.</p><p>Bonne journée,</p><p>L’équipe BAL</p>`,
+  }),
   contact: ({ firstName, lastName, email, message, subject }) => {
     return {
       from: process.env.SMTP_FROM || "adresse@data.gouv.fr",

--- a/server/lib/mailer/mail-to-email-verification-template.ts
+++ b/server/lib/mailer/mail-to-email-verification-template.ts
@@ -727,9 +727,7 @@ export const getEmailVerificationTemplate = ({ subject, verificationLink }) => `
                                             font-size: 14px;
                                           "
                                         >
-                                          Voici le lien pour participer à
-                                          l'évènement
-                                          <a href="${verificationLink}">Vérifier mon email</a>
+                                          Veuillez cliquer sur <a href="${verificationLink}">ce lien</a> pour vérifier votre adresse email.
                                         </p>
                                       <br />
                                       <p

--- a/server/lib/mailer/mail-to-email-verification-template.ts
+++ b/server/lib/mailer/mail-to-email-verification-template.ts
@@ -1,0 +1,864 @@
+export const getEmailVerificationTemplate = ({ subject, verificationLink }) => `
+  <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+  <html
+    xmlns="http://www.w3.org/1999/xhtml"
+    xmlns:v="urn:schemas-microsoft-com:vml"
+    xmlns:o="urn:schemas-microsoft-com:office:office"
+  >
+    <head>
+      <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
+      <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+      <meta name="format-detection" content="telephone=no" />
+      <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+      <title>${subject}</title>
+      <style type="text/css" emogrify="no">
+        #outlook a {
+          padding: 0;
+        }
+        .ExternalClass {
+          width: 100%;
+        }
+        .ExternalClass,
+        .ExternalClass p,
+        .ExternalClass span,
+        .ExternalClass font,
+        .ExternalClass td,
+        .ExternalClass div {
+          line-height: 100%;
+        }
+        table td {
+          border-collapse: collapse;
+          mso-line-height-rule: exactly;
+        }
+        .editable.image {
+          font-size: 0 !important;
+          line-height: 0 !important;
+        }
+        .nl2go_preheader {
+          display: none !important;
+          mso-hide: all !important;
+          mso-line-height-rule: exactly;
+          visibility: hidden !important;
+          line-height: 0px !important;
+          font-size: 0px !important;
+        }
+        body {
+          width: 100% !important;
+          -webkit-text-size-adjust: 100%;
+          -ms-text-size-adjust: 100%;
+          margin: 0;
+          padding: 0;
+        }
+        img {
+          outline: none;
+          text-decoration: none;
+          -ms-interpolation-mode: bicubic;
+        }
+        a img {
+          border: none;
+        }
+        table {
+          border-collapse: collapse;
+          mso-table-lspace: 0pt;
+          mso-table-rspace: 0pt;
+        }
+        th {
+          font-weight: normal;
+          text-align: left;
+        }
+        *[class="gmail-fix"] {
+          display: none !important;
+        }
+      </style>
+      <style type="text/css" emogrify="no">
+        @media (max-width: 600px) {
+          .gmx-killpill {
+            content: " \x03D1";
+          }
+        }
+      </style>
+      <style type="text/css" emogrify="no">
+        @media (max-width: 600px) {
+          .gmx-killpill {
+            content: " \x03D1";
+          }
+          .r0-o {
+            border-style: solid !important;
+            margin: 0 auto 0 auto !important;
+            width: 320px !important;
+          }
+          .r1-i {
+            background-color: #f9fafc !important;
+          }
+          .r2-c {
+            box-sizing: border-box !important;
+            text-align: center !important;
+            valign: top !important;
+            width: 100% !important;
+          }
+          .r3-o {
+            border-style: solid !important;
+            margin: 0 auto 0 auto !important;
+            width: 100% !important;
+          }
+          .r4-i {
+            background-color: #ffffff !important;
+            padding-bottom: 20px !important;
+            padding-left: 15px !important;
+            padding-right: 15px !important;
+            padding-top: 20px !important;
+          }
+          .r5-c {
+            box-sizing: border-box !important;
+            display: block !important;
+            valign: top !important;
+            width: 100% !important;
+          }
+          .r6-o {
+            border-style: solid !important;
+            width: 100% !important;
+          }
+          .r7-i {
+            padding-left: 0px !important;
+            padding-right: 0px !important;
+          }
+          .r8-c {
+            box-sizing: border-box !important;
+            text-align: left !important;
+            valign: top !important;
+            width: 100% !important;
+          }
+          .r9-o {
+            border-style: solid !important;
+            margin: 0 auto 0 0 !important;
+            width: 100% !important;
+          }
+          .r10-i {
+            padding-bottom: 0px !important;
+            padding-top: 0px !important;
+          }
+          .r11-i {
+            background-color: transparent !important;
+          }
+          .r12-i {
+            background-color: #ffffff !important;
+            padding-bottom: 0px !important;
+            padding-left: 15px !important;
+            padding-right: 15px !important;
+            padding-top: 0px !important;
+          }
+          .r13-i {
+            padding-bottom: 10px !important;
+            padding-top: 10px !important;
+            text-align: center !important;
+          }
+          .r14-i {
+            text-align: left !important;
+          }
+          .r15-o {
+            border-style: solid !important;
+            margin: 0 0 0 auto !important;
+            width: 100% !important;
+          }
+          .r16-i {
+            padding: 0 !important;
+            text-align: center !important;
+          }
+          .r17-r {
+            background-color: #2b89cf !important;
+            border-color: #000000 !important;
+            border-radius: 4px !important;
+            border-width: 0px !important;
+            box-sizing: border-box;
+            height: initial !important;
+            padding: 0 !important;
+            padding-bottom: 6px !important;
+            padding-left: 5px !important;
+            padding-right: 5px !important;
+            padding-top: 6px !important;
+            text-align: center !important;
+            width: 100% !important;
+          }
+          body {
+            -webkit-text-size-adjust: none;
+          }
+          .nl2go-responsive-hide {
+            display: none;
+          }
+          .nl2go-body-table {
+            min-width: unset !important;
+          }
+          .mobshow {
+            height: auto !important;
+            overflow: visible !important;
+            max-height: unset !important;
+            visibility: visible !important;
+            border: none !important;
+          }
+          .resp-table {
+            display: inline-table !important;
+          }
+          .magic-resp {
+            display: table-cell !important;
+          }
+        }
+      </style>
+      <style type="text/css">
+        p,
+        h1,
+        h2,
+        h3,
+        h4,
+        ol,
+        ul,
+        li {
+          margin: 0;
+        }
+        a,
+        a:link {
+          color: #0092ff;
+          text-decoration: underline;
+        }
+        .nl2go-default-textstyle {
+          color: #3b3f44;
+          font-family: arial, helvetica, sans-serif;
+          font-size: 16px;
+          line-height: 1.2;
+          word-break: break-word;
+        }
+        .default-button {
+          color: #ffffff;
+          font-family: arial, helvetica, sans-serif;
+          font-size: 16px;
+          font-style: normal;
+          font-weight: normal;
+          line-height: 1.15;
+          text-decoration: none;
+          word-break: break-word;
+        }
+        .default-heading3 {
+          color: #1f2d3d;
+          font-family: arial, helvetica, sans-serif;
+          font-size: 24px;
+          word-break: break-word;
+        }
+        .default-heading4 {
+          color: #1f2d3d;
+          font-family: arial, helvetica, sans-serif;
+          font-size: 18px;
+          word-break: break-word;
+        }
+        .default-heading1 {
+          color: #1f2d3d;
+          font-family: arial, helvetica, sans-serif;
+          font-size: 36px;
+          word-break: break-word;
+        }
+        .default-heading2 {
+          color: #1f2d3d;
+          font-family: arial, helvetica, sans-serif;
+          font-size: 32px;
+          word-break: break-word;
+        }
+        a[x-apple-data-detectors] {
+          color: inherit !important;
+          text-decoration: inherit !important;
+          font-size: inherit !important;
+          font-family: inherit !important;
+          font-weight: inherit !important;
+          line-height: inherit !important;
+        }
+        .no-show-for-you {
+          border: none;
+          display: none;
+          float: none;
+          font-size: 0;
+          height: 0;
+          line-height: 0;
+          max-height: 0;
+          mso-hide: all;
+          overflow: hidden;
+          table-layout: fixed;
+          visibility: hidden;
+          width: 0;
+        }
+      </style>
+      <!--[if mso
+        ]><xml>
+          <o:OfficeDocumentSettings>
+            <o:AllowPNG /> <o:PixelsPerInch>96</o:PixelsPerInch>
+          </o:OfficeDocumentSettings>
+        </xml><!
+      [endif]-->
+      <style type="text/css">
+        a:link {
+          color: #0092ff;
+          text-decoration: underline;
+        }
+      </style>
+    </head>
+    <body
+      bgcolor="#f9fafc"
+      text="#3b3f44"
+      link="#0092ff"
+      yahoo="fix"
+      style="background-color: #f9fafc; padding-top: 38px"
+    >
+      <table
+        cellspacing="0"
+        cellpadding="0"
+        border="0"
+        role="presentation"
+        class="nl2go-body-table"
+        width="100%"
+        style="background-color: #f9fafc; width: 100%"
+      >
+        <tr>
+          <td>
+            <table
+              cellspacing="0"
+              cellpadding="0"
+              border="0"
+              role="presentation"
+              width="590"
+              align="center"
+              class="r0-o"
+              style="table-layout: fixed; width: 590px"
+            >
+              <tr>
+                <td valign="top" class="r1-i" style="background-color: #f9fafc">
+                  <table
+                    cellspacing="0"
+                    cellpadding="0"
+                    border="0"
+                    role="presentation"
+                    width="100%"
+                    align="center"
+                    class="r3-o"
+                    style="table-layout: fixed; width: 100%"
+                  >
+                    <tr>
+                      <td
+                        class="r4-i"
+                        style="
+                          background-color: #ffffff;
+                          padding-bottom: 20px;
+                          padding-left: 20px;
+                          padding-right: 20px;
+                          padding-top: 20px;
+                        "
+                      >
+                        <table
+                          width="100%"
+                          cellspacing="0"
+                          cellpadding="0"
+                          border="0"
+                          role="presentation"
+                        >
+                          <tr>
+                            <th
+                              width="100%"
+                              valign="top"
+                              class="r5-c"
+                              style="font-weight: normal"
+                            >
+                              <table
+                                cellspacing="0"
+                                cellpadding="0"
+                                border="0"
+                                role="presentation"
+                                width="100%"
+                                class="r6-o"
+                                style="table-layout: fixed; width: 100%"
+                              >
+                                <tr>
+                                  <td
+                                    valign="top"
+                                    class="r7-i"
+                                    style="padding-left: 5px; padding-right: 5px"
+                                  >
+                                    <table
+                                      width="100%"
+                                      cellspacing="0"
+                                      cellpadding="0"
+                                      border="0"
+                                      role="presentation"
+                                    >
+                                      <tr>
+                                        <td class="r8-c" align="left">
+                                          <table
+                                            cellspacing="0"
+                                            cellpadding="0"
+                                            border="0"
+                                            role="presentation"
+                                            width="550"
+                                            class="r9-o"
+                                            style="
+                                              table-layout: fixed;
+                                              width: 550px;
+                                            "
+                                          >
+                                            <tr>
+                                              <td class="r10-i">
+                                                <a
+                                                  href="https://adresse.data.gouv.fr/"
+                                                  target="_blank"
+                                                  style="
+                                                    color: #0092ff;
+                                                    text-decoration: underline;
+                                                  "
+                                                >
+                                                  <img
+                                                    src="https://img.mailinblue.com/2265896/images/rnb/original/63c02a863be92f0fb24630a9.jpg?t=1675237590354"
+                                                    width="550"
+                                                    alt="Charte de la Base Adresse Locale"
+                                                    border="0"
+                                                    style="
+                                                      display: block;
+                                                      width: 100%;
+                                                    "
+                                                /></a>
+                                              </td>
+                                            </tr>
+                                          </table>
+                                        </td>
+                                      </tr>
+                                    </table>
+                                  </td>
+                                </tr>
+                              </table>
+                            </th>
+                          </tr>
+                        </table>
+                      </td>
+                    </tr>
+                  </table>
+                </td>
+              </tr>
+            </table>
+            <table
+              cellspacing="0"
+              cellpadding="0"
+              border="0"
+              role="presentation"
+              width="100%"
+              align="center"
+              class="r3-o"
+              style="table-layout: fixed; width: 100%"
+            >
+              <tr>
+                <td valign="top" class="r1-i" style="background-color: #f9fafc">
+                  <table
+                    cellspacing="0"
+                    cellpadding="0"
+                    border="0"
+                    role="presentation"
+                    width="590"
+                    align="center"
+                    class="r0-o"
+                    style="table-layout: fixed; width: 590px"
+                  >
+                    <tr>
+                      <th
+                        width="100%"
+                        valign="top"
+                        class="r5-c"
+                        style="font-weight: normal"
+                      >
+                        <table
+                          cellspacing="0"
+                          cellpadding="0"
+                          border="0"
+                          role="presentation"
+                          width="590"
+                          align="center"
+                          class="r3-o"
+                          style="table-layout: fixed; width: 590px"
+                        >
+                          <tr>
+                            <td
+                              height="20"
+                              class="r11-i"
+                              style="
+                                font-size: 20px;
+                                line-height: 20px;
+                                background-color: transparent;
+                              "
+                            >
+                              ­
+                            </td>
+                          </tr>
+                        </table>
+                      </th>
+                    </tr>
+                  </table>
+                </td>
+              </tr>
+            </table>
+            <table
+              cellspacing="0"
+              cellpadding="0"
+              border="0"
+              role="presentation"
+              width="590"
+              align="center"
+              class="r0-o"
+              style="table-layout: fixed; width: 590px"
+            >
+              <tr>
+                <td valign="top" class="r1-i" style="background-color: #f9fafc">
+                  <table
+                    cellspacing="0"
+                    cellpadding="0"
+                    border="0"
+                    role="presentation"
+                    width="100%"
+                    align="center"
+                    class="r3-o"
+                    style="table-layout: fixed; width: 100%"
+                  >
+                    <tr>
+                      <td
+                        class="r12-i"
+                        style="
+                          background-color: #ffffff;
+                          padding-left: 20px;
+                          padding-right: 20px;
+                        "
+                      >
+                        <table
+                          width="100%"
+                          cellspacing="0"
+                          cellpadding="0"
+                          border="0"
+                          role="presentation"
+                        >
+                          <tr>
+                            <th
+                              width="100%"
+                              valign="top"
+                              class="r5-c"
+                              style="font-weight: normal"
+                            >
+                              <table
+                                cellspacing="0"
+                                cellpadding="0"
+                                border="0"
+                                role="presentation"
+                                width="100%"
+                                class="r6-o"
+                                style="table-layout: fixed; width: 100%"
+                              >
+                                <tr>
+                                  <td
+                                    valign="top"
+                                    class="r7-i"
+                                    style="padding-left: 5px; padding-right: 5px"
+                                  >
+                                    <table
+                                      width="100%"
+                                      cellspacing="0"
+                                      cellpadding="0"
+                                      border="0"
+                                      role="presentation"
+                                    >
+                                      <tr>
+                                        <td class="r8-c" align="left">
+                                          <table
+                                            cellspacing="0"
+                                            cellpadding="0"
+                                            border="0"
+                                            role="presentation"
+                                            width="100%"
+                                            class="r9-o"
+                                            style="
+                                              table-layout: fixed;
+                                              width: 100%;
+                                            "
+                                          >
+                                            <tr>
+                                              <td
+                                                align="center"
+                                                valign="top"
+                                                class="r13-i nl2go-default-textstyle"
+                                                style="
+                                                  color: #3b3f44;
+                                                  font-family: arial, helvetica,
+                                                    sans-serif;
+                                                  font-size: 16px;
+                                                  line-height: 1.2;
+                                                  word-break: break-word;
+                                                  padding-bottom: 10px;
+                                                  padding-top: 10px;
+                                                  text-align: center;
+                                                "
+                                              >
+                                                <div>
+                                                  <p
+                                                    style="
+                                                      margin: 0;
+                                                      font-family: &quot;Marianne&quot;,
+                                                        &quot;Arial&quot;,
+                                                        Helvetica, sans-serif;
+                                                      font-size: 24px;
+                                                      color: #3c4858;
+                                                    "
+                                                  >
+                                                    <span style="font-size: 20px"
+                                                      ><strong
+                                                        >${subject}
+                                                      </strong></span
+                                                    >
+                                                  </p>
+                                                </div>
+                                              </td>
+                                            </tr>
+                                          </table>
+                                        </td>
+                                      </tr>
+                                    </table>
+                                  </td>
+                                </tr>
+                              </table>
+                            </th>
+                          </tr>
+                        </table>
+                      </td>
+                    </tr>
+                  </table>
+                  <table
+                    cellspacing="0"
+                    cellpadding="0"
+                    border="0"
+                    role="presentation"
+                    width="100%"
+                    align="center"
+                    class="r3-o"
+                    style="table-layout: fixed; width: 100%"
+                  >
+                    <tr>
+                      <td
+                        class="r4-i"
+                        style="
+                          background-color: #ffffff;
+                          padding-bottom: 20px;
+                          padding-left: 20px;
+                          padding-right: 20px;
+                          padding-top: 20px;
+                        "
+                      >
+                        <table
+                          width="100%"
+                          cellspacing="0"
+                          cellpadding="0"
+                          border="0"
+                          role="presentation"
+                        >
+                          <tr>
+                            <th
+                              width="100%"
+                              valign="top"
+                              class="r5-c"
+                              style="font-weight: normal"
+                            >
+                              <table
+                                cellspacing="0"
+                                cellpadding="0"
+                                border="0"
+                                role="presentation"
+                                width="100%"
+                                align="left"
+                                class="r9-o"
+                                style="table-layout: fixed; width: 100%"
+                              >
+                                <tr>
+                                  <td
+                                    align="left"
+                                    valign="top"
+                                    class="r14-i nl2go-default-textstyle"
+                                    style="
+                                      color: #3b3f44;
+                                      font-family: arial, helvetica, sans-serif;
+                                      font-size: 16px;
+                                      line-height: 1.2;
+                                      word-break: break-word;
+                                      text-align: left;
+                                    "
+                                  >
+                                    <div>
+                                      <p
+                                        style="
+                                          margin: 0;
+                                          color: #3c4858;
+                                          font-family: &quot;Marianne&quot;,
+                                            &quot;Arial&quot;, Helvetica,
+                                            sans-serif;
+                                          font-size: 14px;
+                                        "
+                                      >
+                                        <span
+                                          style="
+                                            font-family: Arial, helvetica,
+                                              sans-serif;
+                                            font-size: 14px;
+                                          "
+                                          >Bonjour,</span
+                                        >
+                                        <br />
+                                        <br />
+                                      </p>
+  
+                                      <p
+                                        style="
+                                          font-family: Arial, helvetica,
+                                            sans-serif;
+                                          font-size: 14px;
+                                        "
+                                      >
+                                        Nous avons bien reçu votre avis. Pour le
+                                        valider, nous avons besoin de vérifier
+                                        votre adresse email.
+                                      </p>
+                                      <br />
+                                      <p
+                                          style="
+                                            font-family: Arial, helvetica,
+                                              sans-serif;
+                                            font-size: 14px;
+                                          "
+                                        >
+                                          Voici le lien pour participer à
+                                          l'évènement
+                                          <a href="${verificationLink}">Vérifier mon email</a>
+                                        </p>
+                                      <br />
+                                      <p
+                                        style="
+                                          font-family: Arial, helvetica,
+                                            sans-serif;
+                                          font-size: 14px;
+                                        "
+                                      >
+                                        Ceci est un message automatique, mais vous
+                                        pouvez nous contacter via l'email
+                                        <b>adresse@data.gouv.fr</b> pour obtenir
+                                        des informations complémentaires.
+                                      </p>
+                                    </div>
+                                  </td>
+                                </tr>
+                              </table>
+                            </th>
+                          </tr>
+                        </table>
+                      </td>
+                    </tr>
+                  </table>
+                  <table
+                    cellspacing="0"
+                    cellpadding="0"
+                    border="0"
+                    role="presentation"
+                    width="100%"
+                    align="center"
+                    class="r3-o"
+                    style="table-layout: fixed; width: 100%"
+                  >
+                    <tr>
+                      <td
+                        class="r4-i"
+                        style="
+                          background-color: #ffffff;
+                          padding-bottom: 20px;
+                          padding-left: 20px;
+                          padding-right: 20px;
+                          padding-top: 20px;
+                        "
+                      >
+                        <table
+                          width="100%"
+                          cellspacing="0"
+                          cellpadding="0"
+                          border="0"
+                          role="presentation"
+                        >
+                          <tr>
+                            <th
+                              width="100%"
+                              valign="top"
+                              class="r5-c"
+                              style="font-weight: normal"
+                            >
+                              <table
+                                cellspacing="0"
+                                cellpadding="0"
+                                border="0"
+                                role="presentation"
+                                width="100%"
+                                align="left"
+                                class="r9-o"
+                                style="table-layout: fixed; width: 100%"
+                              >
+                                <tr>
+                                  <td
+                                    align="left"
+                                    valign="top"
+                                    class="r14-i nl2go-default-textstyle"
+                                    style="
+                                      color: #3b3f44;
+                                      font-family: arial, helvetica, sans-serif;
+                                      font-size: 16px;
+                                      line-height: 1.2;
+                                      word-break: break-word;
+                                      text-align: left;
+                                    "
+                                  >
+                                    <div>
+                                      <p
+                                        style="
+                                          margin: 0;
+                                          font-family: &quot;Marianne&quot;,
+                                            &quot;Arial&quot;, Helvetica,
+                                            sans-serif;
+                                          font-size: 14px;
+                                          color: #3c4858;
+                                        "
+                                      >
+                                        <span
+                                          >Cordialement,<br /><br /><em
+                                            >L’équipe
+                                            <a
+                                              href="https://adresse.data.gouv.fr/"
+                                              style="
+                                                color: #0092ff;
+                                                text-decoration: underline;
+                                              "
+                                              ><span
+                                                style="
+                                                  text-decoration: underline;
+                                                  color: rgb(43, 137, 207);
+                                                "
+                                                >adresse.data.gouv.fr</span
+                                              ></a
+                                            ></em
+                                          ></span
+                                        >
+                                      </p>
+                                    </div>
+                                  </td>
+                                </tr>
+                              </table>
+                            </th>
+                          </tr>
+                        </table>
+                      </td>
+                    </tr>
+                  </table>
+                </td>
+              </tr>
+            </table>
+          </td>
+        </tr>
+      </table>
+    </body>
+  </html>`;

--- a/server/lib/mailer/service.ts
+++ b/server/lib/mailer/service.ts
@@ -143,3 +143,15 @@ export async function sendParticipationEvenement(
 
   return true;
 }
+
+export async function sendReviewReceived(partenaireId: string) {
+  const template = templates.reviewReceived({ partenaireId });
+
+  const response = await transport.sendMail(template);
+
+  if (!response) {
+    throw new Error("Une erreur est survenue lors de l'envoi de l'email");
+  }
+
+  return true;
+}

--- a/server/lib/mailer/service.ts
+++ b/server/lib/mailer/service.ts
@@ -155,3 +155,18 @@ export async function sendReviewReceived(partenaireId: string) {
 
   return true;
 }
+
+export async function sendEmailVerification(
+  email: string,
+  verificationLink: string
+) {
+  const template = templates.emailVerification(verificationLink, email);
+
+  const response = await transport.sendMail(template);
+
+  if (!response) {
+    throw new Error("Une erreur est survenue lors de l'envoi de l'email");
+  }
+
+  return true;
+}

--- a/server/lib/partenaire-de-la-charte/controller.ts
+++ b/server/lib/partenaire-de-la-charte/controller.ts
@@ -128,7 +128,7 @@ partenaireDeLaCharteRoutes.delete("/:id", routeGuard, async (req, res) => {
   }
 });
 
-partenaireDeLaCharteRoutes.post("/:id/review", async (req, res) => {
+partenaireDeLaCharteRoutes.post("/:id/reviews", async (req, res) => {
   try {
     const review = await ReviewsService.addReview(req.params.id, req.body);
 

--- a/server/lib/partenaire-de-la-charte/controller.ts
+++ b/server/lib/partenaire-de-la-charte/controller.ts
@@ -3,7 +3,10 @@ import cors from "cors";
 import { shuffle } from "../../utils/random";
 import routeGuard from "../../route-guard";
 import * as PartenaireDeLaCharteService from "./service";
-import { PartenaireDeLaCharteServiceEnum } from "./entity";
+import {
+  PartenaireDeLaCharteServiceEnum,
+  PartenaireDeLaCharteTypeEnum,
+} from "./entity";
 import { Logger } from "../../utils/logger.utils";
 
 const partenaireDeLaCharteRoutes = express.Router();
@@ -57,7 +60,11 @@ partenaireDeLaCharteRoutes.get("/random", async (req, res) => {
 
 partenaireDeLaCharteRoutes.get("/services", async (req, res) => {
   try {
-    res.json(Object.values(PartenaireDeLaCharteServiceEnum));
+    const result = await PartenaireDeLaCharteService.findServicesWithCount(
+      req.query
+    );
+
+    res.json(result);
   } catch (err) {
     Logger.error(`Impossible de récupérer les services de partenaires`, err);
     res.status(500).json({ error: err.message });

--- a/server/lib/partenaire-de-la-charte/controller.ts
+++ b/server/lib/partenaire-de-la-charte/controller.ts
@@ -19,11 +19,9 @@ partenaireDeLaCharteRoutes.get("/", isAdmin, async (req, res) => {
     );
 
     res.json(
-      (req as any).isAdmin
-        ? partenairesDeLaCharte
-        : partenairesDeLaCharte.map((partenaire) =>
-            mapPartenairePublicReviews(partenaire)
-          )
+      partenairesDeLaCharte.map((partenaire) =>
+        mapPartenairePublicReviews(partenaire, (req as any).isAdmin)
+      )
     );
   } catch (err) {
     Logger.error(`Impossible de récupérer les partenaires`, err);
@@ -43,11 +41,9 @@ partenaireDeLaCharteRoutes.get("/paginated", isAdmin, async (req, res) => {
 
     res.json({
       ...paginatedPartenairesDeLaCharte,
-      data: (req as any).isAdmin
-        ? paginatedPartenairesDeLaCharte.data
-        : paginatedPartenairesDeLaCharte.data.map((partenaire) =>
-            mapPartenairePublicReviews(partenaire)
-          ),
+      data: paginatedPartenairesDeLaCharte.data.map((partenaire) =>
+        mapPartenairePublicReviews(partenaire, (req as any).isAdmin)
+      ),
     });
   } catch (err) {
     Logger.error(`Impossible de récupérer les partenaires`, err);
@@ -99,9 +95,7 @@ partenaireDeLaCharteRoutes.get("/:id", isAdmin, async (req, res) => {
       await PartenaireDeLaCharteService.findOneOrFail(req.params.id);
 
     res.json(
-      (req as any).isAdmin
-        ? partenaireDeLaCharte
-        : mapPartenairePublicReviews(partenaireDeLaCharte)
+      mapPartenairePublicReviews(partenaireDeLaCharte, (req as any).isAdmin)
     );
   } catch (err) {
     Logger.error(`Impossible de récupérer le partenaire`, err);

--- a/server/lib/partenaire-de-la-charte/controller.ts
+++ b/server/lib/partenaire-de-la-charte/controller.ts
@@ -148,33 +148,4 @@ partenaireDeLaCharteRoutes.post("/:id/review", async (req, res) => {
   }
 });
 
-partenaireDeLaCharteRoutes.put("/reviews/:id", routeGuard, async (req, res) => {
-  try {
-    const updatedReview = await ReviewsService.updateReview(
-      req.params.id,
-      req.body
-    );
-
-    res.json(updatedReview);
-  } catch (err) {
-    Logger.error(`Impossible de publier l'avis`, err);
-    res.status(500).json({ error: err.message });
-  }
-});
-
-partenaireDeLaCharteRoutes.delete(
-  "/reviews/:id",
-  routeGuard,
-  async (req, res) => {
-    try {
-      await ReviewsService.deleteReview(req.params.id);
-
-      res.json(true);
-    } catch (err) {
-      Logger.error(`Impossible de supprimer l'avis`, err);
-      res.status(500).json({ error: err.message });
-    }
-  }
-);
-
 export default partenaireDeLaCharteRoutes;

--- a/server/lib/partenaire-de-la-charte/dto.ts
+++ b/server/lib/partenaire-de-la-charte/dto.ts
@@ -34,7 +34,7 @@ export class PartenaireDeLaCharteDTO {
 
   @IsOptional()
   @IsBase64()
-  picture: string;
+  picture?: string;
 
   @IsString()
   contactLastName: string;

--- a/server/lib/partenaire-de-la-charte/dto.ts
+++ b/server/lib/partenaire-de-la-charte/dto.ts
@@ -19,6 +19,7 @@ export interface PartenaireDeLaCharteQuery {
   codeDepartement?: string;
   search?: string;
   withoutPictures?: boolean;
+  shuffleResults?: boolean;
   services?:
     | PartenaireDeLaCharteServiceEnum
     | PartenaireDeLaCharteServiceEnum[];

--- a/server/lib/partenaire-de-la-charte/entity.ts
+++ b/server/lib/partenaire-de-la-charte/entity.ts
@@ -132,5 +132,5 @@ export class PartenaireDeLaCharte {
   isPerimeterFrance: boolean;
 
   @OneToMany(() => Review, (review) => review.partenaire, { eager: true })
-  reviews?: Relation<Review>[];
+  reviews?: Relation<Partial<Review>>[];
 }

--- a/server/lib/partenaire-de-la-charte/entity.ts
+++ b/server/lib/partenaire-de-la-charte/entity.ts
@@ -3,9 +3,12 @@ import {
   CreateDateColumn,
   DeleteDateColumn,
   Entity,
+  OneToMany,
   PrimaryColumn,
+  Relation,
   UpdateDateColumn,
 } from "typeorm";
+import { Review } from "./reviews/entity";
 
 export enum PartenaireDeLaCharteServiceEnum {
   FORMATION = "formation",
@@ -38,7 +41,7 @@ export class PartenaireDeLaCharte {
   name: string;
 
   @Column("text", { nullable: true })
-  picture: string;
+  picture?: string;
 
   @Column("text", { nullable: false, name: "contact_last_name" })
   contactLastName: string;
@@ -127,4 +130,7 @@ export class PartenaireDeLaCharte {
 
   @Column("boolean", { nullable: true, name: "is_perimeter_france" })
   isPerimeterFrance: boolean;
+
+  @OneToMany(() => Review, (review) => review.partenaire, { eager: true })
+  reviews?: Relation<Review>[];
 }

--- a/server/lib/partenaire-de-la-charte/reviews/controller.ts
+++ b/server/lib/partenaire-de-la-charte/reviews/controller.ts
@@ -1,0 +1,52 @@
+import express from "express";
+import cors from "cors";
+import routeGuard from "../../../route-guard";
+import * as ReviewsService from "./service";
+import { Logger } from "../../../utils/logger.utils";
+
+const reviewsRoutes = express.Router();
+
+reviewsRoutes.use(express.json());
+reviewsRoutes.use(cors());
+
+reviewsRoutes.get("/:id/:token", async (req, res) => {
+  try {
+    await ReviewsService.verifyEmail(req.params.id, req.params.token);
+    res.send("Votre email a bien été vérifié");
+  } catch (err) {
+    Logger.error(
+      `Une erreur est survenue lors de la vérification de l'email`,
+      err
+    );
+    res
+      .status(500)
+      .send("Une erreur est survenue lors de la vérification de l'email");
+  }
+});
+
+reviewsRoutes.put("/:id", routeGuard, async (req, res) => {
+  try {
+    const updatedReview = await ReviewsService.updateReview(
+      req.params.id,
+      req.body
+    );
+
+    res.json(updatedReview);
+  } catch (err) {
+    Logger.error(`Impossible de publier l'avis`, err);
+    res.status(500).json({ error: err.message });
+  }
+});
+
+reviewsRoutes.delete("/:id", routeGuard, async (req, res) => {
+  try {
+    await ReviewsService.deleteReview(req.params.id);
+
+    res.json(true);
+  } catch (err) {
+    Logger.error(`Impossible de supprimer l'avis`, err);
+    res.status(500).json({ error: err.message });
+  }
+});
+
+export default reviewsRoutes;

--- a/server/lib/partenaire-de-la-charte/reviews/controller.ts
+++ b/server/lib/partenaire-de-la-charte/reviews/controller.ts
@@ -12,7 +12,9 @@ reviewsRoutes.use(cors());
 reviewsRoutes.get("/:id/:token", async (req, res) => {
   try {
     await ReviewsService.verifyEmail(req.params.id, req.params.token);
-    res.send("Votre email a bien été vérifié");
+    res.send(
+      "Merci, votre email a bien été vérifié. Si votre avis est validé, il sera publié prochainement."
+    );
   } catch (err) {
     Logger.error(
       `Une erreur est survenue lors de la vérification de l'email`,

--- a/server/lib/partenaire-de-la-charte/reviews/entity.ts
+++ b/server/lib/partenaire-de-la-charte/reviews/entity.ts
@@ -41,8 +41,11 @@ export class Review {
   @Column("int", { nullable: false })
   rating: number;
 
-  @Column("text", { nullable: true })
+  @Column("text", { nullable: false })
   comment: string;
+
+  @Column("text", { nullable: true })
+  reply?: string;
 
   @Column("bool", {
     nullable: false,

--- a/server/lib/partenaire-de-la-charte/reviews/entity.ts
+++ b/server/lib/partenaire-de-la-charte/reviews/entity.ts
@@ -27,13 +27,13 @@ export class Review {
   partenaire: Relation<PartenaireDeLaCharte>;
 
   @Column("text", { nullable: false })
-  fullname?: string;
-
-  @Column("text", { nullable: true })
-  community?: string;
+  community: string;
 
   @Column("text", { nullable: false })
-  email?: string;
+  email: string;
+
+  @Column("text", { nullable: false })
+  verificationToken: string = Math.random().toString(36).slice(2);
 
   @Column("bool", { nullable: true, name: "is_anonymous" })
   isAnonymous?: boolean;
@@ -44,8 +44,11 @@ export class Review {
   @Column("text", { nullable: true })
   comment: string;
 
-  @Column("bool", { nullable: true, name: "is_published" })
-  isPublished?: boolean;
+  @Column("bool", { nullable: false })
+  isEmailVerified: boolean = false;
+
+  @Column("bool", { nullable: false, name: "is_published" })
+  isPublished: boolean;
 
   @CreateDateColumn({ name: "created_at" })
   createdAt?: Date;

--- a/server/lib/partenaire-de-la-charte/reviews/entity.ts
+++ b/server/lib/partenaire-de-la-charte/reviews/entity.ts
@@ -1,0 +1,55 @@
+import {
+  Column,
+  CreateDateColumn,
+  Entity,
+  Index,
+  JoinColumn,
+  ManyToOne,
+  PrimaryColumn,
+  UpdateDateColumn,
+} from "typeorm";
+import type { Relation } from "typeorm";
+import { PartenaireDeLaCharte } from "../entity";
+
+@Entity({ name: "reviews" })
+export class Review {
+  @PrimaryColumn("varchar", { length: 24 })
+  id: string;
+
+  @Index("IDX_partenaire_de_la_charte__id")
+  @Column("varchar", { length: 24, name: "partenaire_id", nullable: false })
+  partenaireId: string;
+
+  @ManyToOne(() => PartenaireDeLaCharte, (e) => e.reviews, {
+    onDelete: "CASCADE",
+  })
+  @JoinColumn({ name: "partenaire_id" })
+  partenaire: Relation<PartenaireDeLaCharte>;
+
+  @Column("text", { nullable: false })
+  fullname?: string;
+
+  @Column("text", { nullable: true })
+  community?: string;
+
+  @Column("text", { nullable: false })
+  email?: string;
+
+  @Column("bool", { nullable: true, name: "is_anonymous" })
+  isAnonymous?: boolean;
+
+  @Column("int", { nullable: false })
+  rating: number;
+
+  @Column("text", { nullable: true })
+  comment: string;
+
+  @Column("bool", { nullable: true, name: "is_published" })
+  isPublished?: boolean;
+
+  @CreateDateColumn({ name: "created_at" })
+  createdAt?: Date;
+
+  @UpdateDateColumn({ name: "updated_at" })
+  updatedAt?: Date;
+}

--- a/server/lib/partenaire-de-la-charte/reviews/entity.ts
+++ b/server/lib/partenaire-de-la-charte/reviews/entity.ts
@@ -16,7 +16,7 @@ export class Review {
   @PrimaryColumn("varchar", { length: 24 })
   id: string;
 
-  @Index("IDX_partenaire_de_la_charte__id")
+  @Index("IDX_reviews_partenaire_id")
   @Column("varchar", { length: 24, name: "partenaire_id", nullable: false })
   partenaireId: string;
 
@@ -32,11 +32,11 @@ export class Review {
   @Column("text", { nullable: false })
   email: string;
 
-  @Column("text", { nullable: false })
+  @Column("text", { nullable: false, name: "verification_token" })
   verificationToken: string = Math.random().toString(36).slice(2);
 
-  @Column("bool", { nullable: true, name: "is_anonymous" })
-  isAnonymous?: boolean;
+  @Column("bool", { nullable: false, name: "is_anonymous", default: false })
+  isAnonymous?: boolean = false;
 
   @Column("int", { nullable: false })
   rating: number;
@@ -44,11 +44,15 @@ export class Review {
   @Column("text", { nullable: true })
   comment: string;
 
-  @Column("bool", { nullable: false })
+  @Column("bool", {
+    nullable: false,
+    name: "is_email_verified",
+    default: false,
+  })
   isEmailVerified: boolean = false;
 
-  @Column("bool", { nullable: false, name: "is_published" })
-  isPublished: boolean;
+  @Column("bool", { nullable: false, name: "is_published", default: false })
+  isPublished: boolean = false;
 
   @CreateDateColumn({ name: "created_at" })
   createdAt?: Date;

--- a/server/lib/partenaire-de-la-charte/reviews/mapper.ts
+++ b/server/lib/partenaire-de-la-charte/reviews/mapper.ts
@@ -1,0 +1,21 @@
+import { PartenaireDeLaCharte } from "../entity";
+
+export const mapPartenairePublicReviews = (
+  partenaire: PartenaireDeLaCharte
+): PartenaireDeLaCharte => {
+  return {
+    ...partenaire,
+    reviews: (partenaire.reviews || [])
+      .filter((review) => review.isPublished)
+      .map((review) => {
+        const { isAnonymous, fullname, community, email, ...rest } = review;
+        return isAnonymous
+          ? { ...rest }
+          : {
+              ...rest,
+              fullname,
+              community,
+            };
+      }),
+  };
+};

--- a/server/lib/partenaire-de-la-charte/reviews/mapper.ts
+++ b/server/lib/partenaire-de-la-charte/reviews/mapper.ts
@@ -8,12 +8,18 @@ export const mapPartenairePublicReviews = (
     reviews: (partenaire.reviews || [])
       .filter((review) => review.isPublished)
       .map((review) => {
-        const { isAnonymous, fullname, community, email, ...rest } = review;
+        const {
+          isAnonymous,
+          community,
+          email,
+          isEmailVerified,
+          verificationToken,
+          ...rest
+        } = review;
         return isAnonymous
           ? { ...rest }
           : {
               ...rest,
-              fullname,
               community,
             };
       }),

--- a/server/lib/partenaire-de-la-charte/reviews/mapper.ts
+++ b/server/lib/partenaire-de-la-charte/reviews/mapper.ts
@@ -1,27 +1,35 @@
 import { PartenaireDeLaCharte } from "../entity";
 
 export const mapPartenairePublicReviews = (
-  partenaire: PartenaireDeLaCharte
+  partenaire: PartenaireDeLaCharte,
+  isAdmin: boolean
 ): PartenaireDeLaCharte => {
-  return {
-    ...partenaire,
-    reviews: (partenaire.reviews || [])
-      .filter((review) => review.isPublished)
-      .map((review) => {
-        const {
-          isAnonymous,
-          community,
-          email,
-          isEmailVerified,
-          verificationToken,
-          ...rest
-        } = review;
-        return isAnonymous
-          ? { ...rest }
-          : {
-              ...rest,
+  return isAdmin
+    ? {
+        ...partenaire,
+        reviews: (partenaire.reviews || []).filter(
+          (review) => review.isEmailVerified
+        ),
+      }
+    : {
+        ...partenaire,
+        reviews: (partenaire.reviews || [])
+          .filter((review) => review.isPublished)
+          .map((review) => {
+            const {
+              isAnonymous,
               community,
-            };
-      }),
-  };
+              email,
+              isEmailVerified,
+              verificationToken,
+              ...rest
+            } = review;
+            return isAnonymous
+              ? { ...rest }
+              : {
+                  ...rest,
+                  community,
+                };
+          }),
+      };
 };

--- a/server/lib/partenaire-de-la-charte/reviews/service.ts
+++ b/server/lib/partenaire-de-la-charte/reviews/service.ts
@@ -1,4 +1,7 @@
-import { sendReviewReceived } from "../..//mailer/service";
+import {
+  sendReviewReceived,
+  sendEmailVerification,
+} from "../..//mailer/service";
 import { AppDataSource } from "../../../utils/typeorm-client";
 import { Review } from "./entity";
 import * as PartenaireDeLaCharteService from "../service";
@@ -27,6 +30,7 @@ export async function addReview(
     ...payload,
     partenaireId,
     isPublished: false,
+    isEmailVerified: false,
   };
 
   const entityToSave = await reviewRepository.create(review);
@@ -34,7 +38,10 @@ export async function addReview(
   const newRecord = await reviewRepository.save(entityToSave);
 
   try {
-    await sendReviewReceived(partenaireId);
+    await sendEmailVerification(
+      review.email,
+      `${process.env.NEXT_PUBLIC_BAL_ADMIN_URL}/api/reviews/${newRecord.id}/${newRecord.verificationToken}`
+    );
   } catch (error) {
     Logger.error(
       `Une erreur est survenue lors de l'envoie de la notification de review`,
@@ -54,4 +61,24 @@ export async function updateReview(reviewId: string, payload: any) {
 export async function deleteReview(reviewId: string) {
   const review = await findOneOrFail(reviewId);
   await reviewRepository.delete({ id: review.id });
+}
+
+export async function verifyEmail(reviewId: string, token: string) {
+  const review = await findOneOrFail(reviewId);
+
+  if (review.verificationToken === token) {
+    review.isEmailVerified = true;
+    await reviewRepository.save(review);
+
+    try {
+      await sendReviewReceived(review.partenaireId);
+    } catch (error) {
+      Logger.error(
+        `Une erreur est survenue lors de l'envoie de la notification de review`,
+        error
+      );
+    }
+  } else {
+    throw new Error("Token invalide");
+  }
 }

--- a/server/lib/partenaire-de-la-charte/reviews/service.ts
+++ b/server/lib/partenaire-de-la-charte/reviews/service.ts
@@ -55,6 +55,7 @@ export async function addReview(
 export async function updateReview(reviewId: string, payload: any) {
   const review = await findOneOrFail(reviewId);
   review.isPublished = payload.isPublished;
+  review.reply = payload.reply;
   return reviewRepository.save(review);
 }
 

--- a/server/lib/partenaire-de-la-charte/reviews/service.ts
+++ b/server/lib/partenaire-de-la-charte/reviews/service.ts
@@ -1,0 +1,57 @@
+import { sendReviewReceived } from "../..//mailer/service";
+import { AppDataSource } from "../../../utils/typeorm-client";
+import { Review } from "./entity";
+import * as PartenaireDeLaCharteService from "../service";
+import { ObjectId } from "bson";
+import { Logger } from "../../../utils/logger.utils";
+
+const reviewRepository = AppDataSource.getRepository(Review);
+
+export async function findOneOrFail(id: string) {
+  const record = await reviewRepository.findOneByOrFail({ id });
+
+  if (!record) {
+    throw new Error(`Review ${id} introuvable`);
+  }
+
+  return record;
+}
+
+export async function addReview(
+  partenaireId: string,
+  payload: any
+): Promise<Review> {
+  await PartenaireDeLaCharteService.findOneOrFail(partenaireId);
+
+  const review: Review = {
+    ...payload,
+    partenaireId,
+    isPublished: false,
+  };
+
+  const entityToSave = await reviewRepository.create(review);
+  entityToSave.id = new ObjectId().toHexString();
+  const newRecord = await reviewRepository.save(entityToSave);
+
+  try {
+    await sendReviewReceived(partenaireId);
+  } catch (error) {
+    Logger.error(
+      `Une erreur est survenue lors de l'envoie de la notification de review`,
+      error
+    );
+  }
+
+  return newRecord;
+}
+
+export async function updateReview(reviewId: string, payload: any) {
+  const review = await findOneOrFail(reviewId);
+  review.isPublished = payload.isPublished;
+  return reviewRepository.save(review);
+}
+
+export async function deleteReview(reviewId: string) {
+  const review = await findOneOrFail(reviewId);
+  await reviewRepository.delete({ id: review.id });
+}

--- a/server/lib/partenaire-de-la-charte/service.ts
+++ b/server/lib/partenaire-de-la-charte/service.ts
@@ -204,6 +204,21 @@ export async function updateOne(
   return findOneOrFail(id);
 }
 
+export async function findServicesWithCount(
+  query: PartenaireDeLaCharteQuery = {}
+) {
+  const records = await findMany(query);
+
+  const services = records.reduce((acc, record) => {
+    record.services.forEach((service) => {
+      acc[service] = acc[service] ? acc[service] + 1 : 1;
+    });
+    return acc;
+  }, {});
+
+  return services;
+}
+
 export async function deleteOne(id: string): Promise<boolean> {
   await partenaireDeLaCharteRepository.delete({ id });
   return true;

--- a/server/lib/partenaire-de-la-charte/service.ts
+++ b/server/lib/partenaire-de-la-charte/service.ts
@@ -61,6 +61,12 @@ export async function findMany(query: PartenaireDeLaCharteQuery = {}) {
   const queryPG = partenaireDeLaCharteRepository
     .createQueryBuilder("partenaireDeLaCharte")
     .leftJoinAndSelect("partenaireDeLaCharte.reviews", "reviews")
+    .addSelect(
+      "COUNT(case when reviews.is_email_verified = true and reviews.is_published = false then 1 else null end)",
+      "pending_reviews_count"
+    )
+    .groupBy("partenaireDeLaCharte.id, reviews.id")
+    .orderBy("pending_reviews_count", "DESC")
     .where(where);
 
   if (codeDepartement) {

--- a/server/lib/partenaire-de-la-charte/service.ts
+++ b/server/lib/partenaire-de-la-charte/service.ts
@@ -96,8 +96,8 @@ export async function findManyPaginated(
     .createQueryBuilder("partenaireDeLaCharte")
     .leftJoinAndSelect("partenaireDeLaCharte.reviews", "reviews")
     .where(where)
-    .limit(limit)
-    .offset(offset);
+    .take(limit)
+    .skip(offset);
 
   if (codeDepartement) {
     queryPG.andWhere(

--- a/server/lib/partenaire-de-la-charte/service.ts
+++ b/server/lib/partenaire-de-la-charte/service.ts
@@ -65,7 +65,7 @@ export async function findMany(query: PartenaireDeLaCharteQuery = {}) {
 
   if (codeDepartement) {
     queryPG.andWhere(
-      `code_departement @> :arraySearch OR is_perimeter_france IS true`,
+      `(code_departement @> :arraySearch OR is_perimeter_france IS true)`,
       { arraySearch: [codeDepartement] }
     );
   }
@@ -89,7 +89,7 @@ export async function findManyPaginated(
 ) {
   const offset = (page - 1) * limit;
 
-  const { codeDepartement, withoutPictures } = query;
+  const { codeDepartement, withoutPictures, shuffleResults } = query;
   const where: FindOptionsWhere<PartenaireDeLaCharte> = createWherePG(query);
 
   const queryPG = partenaireDeLaCharteRepository
@@ -101,7 +101,7 @@ export async function findManyPaginated(
 
   if (codeDepartement) {
     queryPG.andWhere(
-      `code_departement @> :arraySearch OR is_perimeter_france IS true`,
+      `(code_departement @> :arraySearch OR is_perimeter_france IS true)`,
       { arraySearch: [codeDepartement] }
     );
   }
@@ -123,17 +123,25 @@ export async function findManyPaginated(
     }
   );
 
+  let data = records;
+
+  if (shuffleResults) {
+    data = records.sort(() => Math.random() - 0.5);
+  }
+
+  if (withoutPictures) {
+    data = records.map((record) => {
+      const { picture, ...rest } = record;
+      return rest;
+    });
+  }
+
   return {
     total,
     totalCommunes,
     totalOrganismes,
     totalEntreprises,
-    data: withoutPictures
-      ? records.map((record) => {
-          const { picture, ...rest } = record;
-          return rest;
-        })
-      : records,
+    data,
   };
 }
 

--- a/server/lib/partenaire-de-la-charte/service.ts
+++ b/server/lib/partenaire-de-la-charte/service.ts
@@ -206,7 +206,9 @@ export async function updateOne(
     ? new Date()
     : new Date(payload.signatureDate);
 
-  await partenaireDeLaCharteRepository.update({ id }, payload);
+  const instance = await findOneOrFail(id);
+  Object.assign(instance, payload);
+  await partenaireDeLaCharteRepository.save(instance);
 
   return findOneOrFail(id);
 }

--- a/server/lib/partenaire-de-la-charte/service.ts
+++ b/server/lib/partenaire-de-la-charte/service.ts
@@ -1,5 +1,4 @@
 import { validateOrReject } from "class-validator";
-
 import { sendTemplateMail } from "../mailer/service";
 import { PartenaireDeLaCharteDTO, PartenaireDeLaCharteQuery } from "./dto";
 import { AppDataSource } from "../../utils/typeorm-client";
@@ -60,7 +59,8 @@ export async function findMany(query: PartenaireDeLaCharteQuery = {}) {
   const where: FindOptionsWhere<PartenaireDeLaCharte> = createWherePG(query);
 
   const queryPG = partenaireDeLaCharteRepository
-    .createQueryBuilder()
+    .createQueryBuilder("partenaireDeLaCharte")
+    .leftJoinAndSelect("partenaireDeLaCharte.reviews", "reviews")
     .where(where);
 
   if (codeDepartement) {
@@ -93,7 +93,8 @@ export async function findManyPaginated(
   const where: FindOptionsWhere<PartenaireDeLaCharte> = createWherePG(query);
 
   const queryPG = partenaireDeLaCharteRepository
-    .createQueryBuilder()
+    .createQueryBuilder("partenaireDeLaCharte")
+    .leftJoinAndSelect("partenaireDeLaCharte.reviews", "reviews")
     .where(where)
     .limit(limit)
     .offset(offset);
@@ -122,19 +123,17 @@ export async function findManyPaginated(
     }
   );
 
-  if (withoutPictures) {
-    return records.map((record) => {
-      const { picture, ...rest } = record;
-      return rest;
-    });
-  }
-
   return {
     total,
     totalCommunes,
     totalOrganismes,
     totalEntreprises,
-    data: records,
+    data: withoutPictures
+      ? records.map((record) => {
+          const { picture, ...rest } = record;
+          return rest;
+        })
+      : records,
   };
 }
 

--- a/server/utils/random.ts
+++ b/server/utils/random.ts
@@ -1,3 +1,0 @@
-import { random } from "lodash";
-
-export const shuffle = (array) => array.sort(() => random(0, 1) - 0.5);

--- a/server/utils/typeorm-client.ts
+++ b/server/utils/typeorm-client.ts
@@ -4,11 +4,12 @@ import { PartenaireDeLaCharte } from "../lib/partenaire-de-la-charte/entity";
 import { BalWidget } from "../lib/bal-widget/entity";
 import { Event } from "../lib/events/entity";
 import { Participant } from "../lib/participant/entity";
+import { Review } from "../lib/partenaire-de-la-charte/reviews/entity";
 dotenv.config();
 
 export const AppDataSource = new DataSource({
   type: "postgres",
   url: process.env.POSTGRES_URL,
   schema: "public",
-  entities: [PartenaireDeLaCharte, BalWidget, Event, Participant],
+  entities: [PartenaireDeLaCharte, BalWidget, Event, Participant, Review],
 });

--- a/typeorm.config.ts
+++ b/typeorm.config.ts
@@ -4,6 +4,7 @@ import { PartenaireDeLaCharte } from "./server/lib/partenaire-de-la-charte/entit
 import { Event } from "./server/lib/events/entity";
 import { BalWidget } from "./server/lib/bal-widget/entity";
 import { Participant } from "./server/lib/participant/entity";
+import { Review } from "./server/lib/partenaire-de-la-charte/reviews/entity";
 dotenv.config();
 
 export const AppDataSource = new DataSource({
@@ -11,7 +12,7 @@ export const AppDataSource = new DataSource({
   url: process.env.POSTGRES_URL,
   synchronize: false,
   logging: true,
-  entities: [PartenaireDeLaCharte, Event, BalWidget, Participant],
+  entities: [PartenaireDeLaCharte, Event, BalWidget, Participant, Review],
   migrationsRun: false,
   migrations: ["./migrations/*.ts"],
 });


### PR DESCRIPTION
PR adresse.data.gouv => [gfay_feat_update-pages-partenaire](https://github.com/BaseAdresseNationale/adresse.data.gouv.fr/pull/2039)

- Ajoute une entitée "Review" pour évaluer les entreprises de l'annuaire
- 2 nouveaux templates d'email : vérification d'email lors du dépôt d'une review et notification de dépôt quand l'email est vérifié
- Plusieurs fix sur le filtrage des partenaires
- Supprime le /random (remplacé par un queryParam "shuffleResults")