### PR TITLE
fix: add source change in moissonneur page

### DIFF
--- a/components/communes/revisions-item-moissoneur.tsx
+++ b/components/communes/revisions-item-moissoneur.tsx
@@ -44,7 +44,7 @@ export const RevisionItemMoissoneur = ({
       />
     </td>
     <td className="fr-col fr-my-1v">
-      <RevisionPublication {...publication} />
+      <RevisionPublication publicationMoissoneur={publication} />
     </td>
   </tr>
 );

--- a/components/events/event-participants-table.tsx
+++ b/components/events/event-participants-table.tsx
@@ -35,6 +35,8 @@ const EventParticipantTable = ({
     <div className="fr-table">
       <table>
         <caption>Liste des participants</caption>
+        <p>{participants.length} participant(s)</p>
+        <br />
         <Button
           priority="primary"
           onClick={downloadParticipantCsv}

--- a/components/moissonneur-bal/revision-item.tsx
+++ b/components/moissonneur-bal/revision-item.tsx
@@ -12,15 +12,18 @@ import {
   RevisionStatusMoissoneurEnum,
 } from "types/moissoneur";
 import { formatDate } from "@/lib/util/date";
+import { Revision } from "types/api-depot.types";
 
 interface RevisionItemProps {
   revision: RevisionMoissoneurType;
+  revisionApiDepot: Revision;
   onForcePublishRevision;
   isForcePublishRevisionLoading;
 }
 
 const RevisionItem = ({
   revision,
+  revisionApiDepot,
   onForcePublishRevision,
   isForcePublishRevisionLoading,
 }: RevisionItemProps) => {
@@ -71,7 +74,10 @@ const RevisionItem = ({
         />
       </td>
       <td className="fr-col fr-my-1v">
-        <RevisionPublication {...revision.publication} />
+        <RevisionPublication
+          publicationMoissoneur={revision.publication}
+          revisionApiDepot={revisionApiDepot}
+        />
       </td>
       <td className="fr-col fr-my-1v">
         {revision.fileId && (

--- a/components/revision-publication.tsx
+++ b/components/revision-publication.tsx
@@ -1,38 +1,68 @@
-import {Badge} from '@codegouvfr/react-dsfr/Badge'
+import { Badge } from "@codegouvfr/react-dsfr/Badge";
 
-import type {PublicationMoissoneurType} from '../types/moissoneur'
-import Tooltip from './tooltip'
+import type { PublicationMoissoneurType } from "../types/moissoneur";
+import { RevisionStatusMoissoneurEnum } from "../types/moissoneur";
+import Tooltip from "./tooltip";
+import { Revision } from "types/api-depot.types";
 
-export const RevisionPublication = ({status, errorMessage, currentSourceId, currentClientId}: PublicationMoissoneurType) => {
-  if (status === 'provided-by-other-client') {
+export interface RevisionPublicationProps {
+  publicationMoissoneur: PublicationMoissoneurType;
+  revisionApiDepot: Revision;
+}
+
+export const RevisionPublication = ({
+  publicationMoissoneur,
+  revisionApiDepot,
+}: RevisionPublicationProps) => {
+  const { status, errorMessage, currentSourceId, currentClientId } =
+    publicationMoissoneur;
+  if (status === RevisionStatusMoissoneurEnum.PROVIDED_BY_OTHER_CLIENT) {
     return (
-      <Tooltip text={currentClientId || 'inconnu'}>
-        <Badge severity='warning' noIcon>Publiée par un autre client</Badge>
+      <Tooltip text={currentClientId || "inconnu"}>
+        <Badge severity="warning" noIcon>
+          Publiée par un autre client
+        </Badge>
       </Tooltip>
-    )
+    );
   }
 
-  if (status === 'provided-by-other-source') {
+  if (status === RevisionStatusMoissoneurEnum.PROVIDED_BY_OTHER_SOURCE) {
     return (
-      <Tooltip text={currentSourceId || 'inconnue'}>
-        <Badge severity='error' noIcon>Publiée par une autre source</Badge>
+      <Tooltip text={currentSourceId || "inconnue"}>
+        <Badge severity="error" noIcon>
+          Publiée par une autre source
+        </Badge>
       </Tooltip>
-    )
+    );
   }
 
-  if (status === 'published') {
-    return <Badge severity='success' noIcon>Publiée</Badge>
+  if (status === RevisionStatusMoissoneurEnum.PUBLISHED) {
+    if (
+      revisionApiDepot &&
+      revisionApiDepot.id !== publicationMoissoneur.publishedRevisionId
+    ) {
+      return (
+        <Badge severity="info" noIcon>
+          Remplacée par {revisionApiDepot.client.nom}
+        </Badge>
+      );
+    }
+    return (
+      <Badge severity="success" noIcon>
+        Publiée
+      </Badge>
+    );
   }
 
-  if (status === 'error') {
+  if (status === RevisionStatusMoissoneurEnum.ERROR) {
     return (
       <Tooltip text={errorMessage}>
-        <Badge severity='error' noIcon>Erreur</Badge>
+        <Badge severity="error" noIcon>
+          Erreur
+        </Badge>
       </Tooltip>
-    )
+    );
   }
 
-  return (
-    <Badge noIcon>Non publiée</Badge>
-  )
-}
+  return <Badge noIcon>Non publiée</Badge>;
+};

--- a/components/revision-publication.tsx
+++ b/components/revision-publication.tsx
@@ -7,7 +7,7 @@ import { Revision } from "types/api-depot.types";
 
 export interface RevisionPublicationProps {
   publicationMoissoneur: PublicationMoissoneurType;
-  revisionApiDepot: Revision;
+  revisionApiDepot?: Revision;
 }
 
 export const RevisionPublication = ({

--- a/lib/api-depot.ts
+++ b/lib/api-depot.ts
@@ -177,6 +177,19 @@ export async function getStatPublications(
   }
 }
 
+export async function getCurrentRevisions(
+  codesCommunes: string[]
+): Promise<Revision[]> {
+  const url = new URL(`${NEXT_PUBLIC_API_DEPOT_URL}/current-revisions`);
+  for (const codeCommune of codesCommunes) {
+    url.searchParams.append("codesCommunes", codeCommune);
+  }
+
+  const response = await fetch(url);
+
+  return processResponse(response);
+}
+
 export async function getAllRevisionByCommune(
   codeCommune: string,
   isDemo: boolean = false

--- a/pages/moissonneur-bal/sources/[id].tsx
+++ b/pages/moissonneur-bal/sources/[id].tsx
@@ -4,6 +4,7 @@ import Button from "@codegouvfr/react-dsfr/Button";
 import Alert from "@codegouvfr/react-dsfr/Alert";
 import Badge from "@codegouvfr/react-dsfr/Badge";
 import Pagination from "react-js-pagination";
+import { keyBy } from "lodash";
 
 import {
   getSource,
@@ -26,6 +27,8 @@ import {
   OrganizationMoissoneurType,
 } from "types/moissoneur";
 import Link from "next/link";
+import { Revision } from "types/api-depot.types";
+import { getCurrentRevisions } from "@/lib/api-depot";
 
 const limit = 10;
 
@@ -49,6 +52,9 @@ const MoissoneurSource = ({
   const [currentPage, setCurrentPage] = useState<number>(1);
   const [revisionsIsLoading, setRevisionsIsLoading] = useState<boolean>(false);
   const [revisions, setRevisions] = useState<RevisionMoissoneurType[]>([]);
+  const [indexRevisions, setIndexRevisions] = useState<
+    Record<string, Revision>
+  >({});
   const [forcePublishRevisionStatus, setForcePublishRevisionStatus] = useState<
     string | null
   >(null);
@@ -58,6 +64,10 @@ const MoissoneurSource = ({
     setRevisionsIsLoading(true);
     const revisions: RevisionMoissoneurType[] =
       await getSourceLastUpdatedRevisions(sourceId);
+    const revisionsApiDepot = await getCurrentRevisions(
+      revisions.map((revision) => revision.codeCommune)
+    );
+    setIndexRevisions(keyBy(revisionsApiDepot, "codeCommune"));
     setRevisionsIsLoading(false);
     return revisions;
   }
@@ -314,6 +324,7 @@ const MoissoneurSource = ({
                   <RevisionItem
                     key={revision.id}
                     revision={revision}
+                    revisionApiDepot={indexRevisions[revision.codeCommune]}
                     onForcePublishRevision={() =>
                       onForcePublishRevision(revision.id)
                     }


### PR DESCRIPTION
## Ajout si une source a remplacer la revisions publié par le moissonneur

![Capture d’écran 2025-05-21 à 17 42 06](https://github.com/user-attachments/assets/b3eab2a3-2f57-4b5b-bf43-4853e58d02d9)

## Ajout nombre de participants

![Capture d’écran 2025-05-21 à 17 47 49](https://github.com/user-attachments/assets/fdb30fa9-f66c-4bd3-9f8d-62b19c74e33e)

## PR

- [ ] https://github.com/BaseAdresseNationale/api-depot/pull/160