### PR TITLE
fix: outlook blank email

### DIFF
--- a/server/lib/mailer/mail-to-communes-template.ts
+++ b/server/lib/mailer/mail-to-communes-template.ts
@@ -285,13 +285,6 @@ export const getMailToCommuneTemplate = (
         width: 0;
       }
     </style>
-    <!--[if mso
-      ]><xml>
-        <o:OfficeDocumentSettings>
-          <o:AllowPNG /> <o:PixelsPerInch>96</o:PixelsPerInch>
-        </o:OfficeDocumentSettings>
-      </xml><!
-    [endif]-->
     <style type="text/css">
       a:link {
         color: #0092ff;

--- a/server/lib/mailer/mail-to-email-verification-template.ts
+++ b/server/lib/mailer/mail-to-email-verification-template.ts
@@ -283,13 +283,6 @@ export const getEmailVerificationTemplate = ({ subject, verificationLink }) => `
           width: 0;
         }
       </style>
-      <!--[if mso
-        ]><xml>
-          <o:OfficeDocumentSettings>
-            <o:AllowPNG /> <o:PixelsPerInch>96</o:PixelsPerInch>
-          </o:OfficeDocumentSettings>
-        </xml><!
-      [endif]-->
       <style type="text/css">
         a:link {
           color: #0092ff;

--- a/server/lib/mailer/mail-to-participant-template.ts
+++ b/server/lib/mailer/mail-to-participant-template.ts
@@ -291,13 +291,6 @@ export const getMailToParticipantTemplate = ({
         width: 0;
       }
     </style>
-    <!--[if mso
-      ]><xml>
-        <o:OfficeDocumentSettings>
-          <o:AllowPNG /> <o:PixelsPerInch>96</o:PixelsPerInch>
-        </o:OfficeDocumentSettings>
-      </xml><!
-    [endif]-->
     <style type="text/css">
       a:link {
         color: #0092ff;
@@ -743,7 +736,7 @@ export const getMailToParticipantTemplate = ({
                                         : ""
                                     }
                                     ${
-                                      instructions && instructions !== ''
+                                      instructions && instructions !== ""
                                         ? `<br />
                                       <p
                                         style="


### PR DESCRIPTION
Répare le souci d'email vide sur Outlook 
<img width="1373" height="1006" alt="Capture d’écran 2025-07-18 175329" src="https://github.com/user-attachments/assets/012dbcfa-5e4a-47c3-9c82-df1847fc6ec7" />
<img width="1376" height="1002" alt="Capture d’écran 2025-07-18 175246" src="https://github.com/user-attachments/assets/3162c8da-6b9b-47cd-bfec-d8e8f963c7da" />
