### PR TITLE
feat: create bal

### DIFF
--- a/components/communes/bals-item.tsx
+++ b/components/communes/bals-item.tsx
@@ -2,7 +2,11 @@ import Link from "next/link";
 import { Badge } from "@codegouvfr/react-dsfr/Badge";
 import { Button } from "@codegouvfr/react-dsfr/Button";
 
-import { BaseLocaleType, ImportTypeEnum } from "../../types/mes-adresses";
+import {
+  BaseLocaleType,
+  ImportTypeEnum,
+  StatusBaseLocalEnum,
+} from "../../types/mes-adresses";
 import { computeStatus } from "@/lib/bal-status";
 import { formatDate } from "@/lib/util/date";
 import ToggleSwitch from "@codegouvfr/react-dsfr/ToggleSwitch";
@@ -62,7 +66,12 @@ export const BalsItem = (
       <td>
         <ToggleSwitch
           label=""
-          checked={settings?.otherBalPublishedIgnored || false}
+          disabled={status === StatusBaseLocalEnum.PUBLISHED}
+          checked={
+            status === StatusBaseLocalEnum.PUBLISHED ||
+            settings?.otherBalPublishedIgnored ||
+            false
+          }
           onChange={() => actions.toggleOtherBalPublishedIgnored(item)}
         />
       </td>

--- a/components/communes/bals-item.tsx
+++ b/components/communes/bals-item.tsx
@@ -5,11 +5,12 @@ import { Button } from "@codegouvfr/react-dsfr/Button";
 import type { BaseLocaleType } from "../../types/mes-adresses";
 import { computeStatus } from "@/lib/bal-status";
 import { formatDate } from "@/lib/util/date";
+import ToggleSwitch from "@codegouvfr/react-dsfr/ToggleSwitch";
 
 export const BalsItem = (
   item: BaseLocaleType,
   actions: Record<string, (item: BaseLocaleType) => void>,
-  selectedItem?: string
+  selectedItem?: string,
 ) => {
   const {
     id,
@@ -21,6 +22,7 @@ export const BalsItem = (
     updatedAt,
     nbNumeros,
     nbNumerosCertifies,
+    settings,
   } = item;
 
   const computedStatus = computeStatus(status, sync);
@@ -45,6 +47,13 @@ export const BalsItem = (
       </td>
       <td className="fr-col fr-my-1v">
         {nbNumeros} / {nbNumerosCertifies}
+      </td>
+      <td>
+        <ToggleSwitch
+          label=""
+          checked={settings?.otherBalPublishedIgnored}
+          onChange={() => actions.toggleOtherBalPublishedIgnored(item)}
+        />
       </td>
       <td className="fr-col fr-my-1v">
         <div style={{ width: "150px" }}>

--- a/components/communes/bals-item.tsx
+++ b/components/communes/bals-item.tsx
@@ -51,7 +51,7 @@ export const BalsItem = (
       <td>
         <ToggleSwitch
           label=""
-          checked={settings?.otherBalPublishedIgnored}
+          checked={settings?.otherBalPublishedIgnored || false}
           onChange={() => actions.toggleOtherBalPublishedIgnored(item)}
         />
       </td>

--- a/components/communes/new-bal-form.tsx
+++ b/components/communes/new-bal-form.tsx
@@ -1,0 +1,223 @@
+import React, { useRef, useState } from "react";
+import styled from "styled-components";
+import { Input } from "@codegouvfr/react-dsfr/Input";
+import { Button } from "@codegouvfr/react-dsfr/Button";
+import RadioButtons from "@codegouvfr/react-dsfr/RadioButtons";
+
+type DataSource = "ban" | "file";
+
+type NewBalFormProps = {
+  codeCommune: string;
+  onSubmit: (
+    nom: string,
+    emails: string[],
+    source: DataSource,
+    file: File | null,
+  ) => Promise<void>;
+};
+
+const StyledForm = styled.form`
+  section {
+    margin: 1.5rem 0;
+  }
+
+  .email-input-row {
+    display: flex;
+    align-items: flex-end;
+    gap: 1rem;
+  }
+
+  .email-input-row > :first-child {
+    flex: 1;
+  }
+
+  .email-list {
+    margin-top: 0.5rem;
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.5rem;
+  }
+
+  .email-tag {
+    display: inline-flex;
+    align-items: center;
+    background-color: var(--background-contrast-grey);
+    border-radius: 4px;
+    padding: 0.25rem 0.5rem;
+    font-size: 0.875rem;
+    gap: 0.5rem;
+  }
+
+  .email-tag button {
+    background: none;
+    border: none;
+    cursor: pointer;
+    padding: 0;
+    line-height: 1;
+    color: var(--text-default-grey);
+  }
+
+  .form-controls {
+    display: flex;
+    align-items: center;
+    gap: 1rem;
+  }
+`;
+
+export const NewBalForm = ({ codeCommune, onSubmit }: NewBalFormProps) => {
+  const [nom, setNom] = useState("");
+  const [emails, setEmails] = useState<string[]>([]);
+  const [emailInput, setEmailInput] = useState("");
+  const [source, setSource] = useState<DataSource>("ban");
+  const [file, setFile] = useState<File | null>(null);
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const fileInputRef = useRef<HTMLInputElement>(null);
+
+  const addEmail = () => {
+    const trimmed = emailInput.trim();
+    if (trimmed && !emails.includes(trimmed)) {
+      setEmails((prev) => [...prev, trimmed]);
+    }
+    setEmailInput("");
+  };
+
+  const removeEmail = (email: string) => {
+    setEmails((prev) => prev.filter((e) => e !== email));
+  };
+
+  const handleEmailKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
+    if (e.key === "Enter") {
+      e.preventDefault();
+      addEmail();
+    }
+  };
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (emails.length === 0) return;
+    if (source === "file" && !file) return;
+    setIsSubmitting(true);
+    try {
+      await onSubmit(nom, emails, source, file);
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  return (
+    <StyledForm onSubmit={handleSubmit} className="fr-my-4w">
+      <section>
+        <div className="fr-grid-row fr-grid-row--gutters">
+          <div className="fr-col-6">
+            <Input
+              label="Nom de la BAL *"
+              nativeInputProps={{
+                required: true,
+                value: nom,
+                onChange: (e) => setNom(e.target.value),
+              }}
+            />
+          </div>
+        </div>
+      </section>
+
+      <section>
+        <label className="fr-label">Adresses emails administrateur *</label>
+        <div className="fr-grid-row fr-grid-row--gutters">
+          <div className="fr-col-6">
+            <div className="email-input-row">
+              <Input
+                label=""
+                nativeInputProps={{
+                  type: "email",
+                  value: emailInput,
+                  placeholder: "exemple@domaine.fr",
+                  onChange: (e) => setEmailInput(e.target.value),
+                  onKeyDown: handleEmailKeyDown,
+                }}
+              />
+              <Button
+                type="button"
+                priority="secondary"
+                iconId="fr-icon-add-line"
+                onClick={addEmail}
+                disabled={!emailInput.trim()}
+              >
+                Ajouter
+              </Button>
+            </div>
+            {emails.length > 0 && (
+              <div className="email-list">
+                {emails.map((email) => (
+                  <span key={email} className="email-tag">
+                    {email}
+                    <button
+                      type="button"
+                      onClick={() => removeEmail(email)}
+                      aria-label={`Supprimer ${email}`}
+                    >
+                      ✕
+                    </button>
+                  </span>
+                ))}
+              </div>
+            )}
+          </div>
+        </div>
+      </section>
+
+      <section>
+        <RadioButtons
+          legend="Source des données"
+          options={[
+            {
+              label: "Utiliser la BAN (peuplement automatique)",
+              nativeInputProps: {
+                value: "ban",
+                checked: source === "ban",
+                onChange: () => setSource("ban"),
+              },
+            },
+            {
+              label: "Importer un fichier BAL (CSV)",
+              nativeInputProps: {
+                value: "file",
+                checked: source === "file",
+                onChange: () => setSource("file"),
+              },
+            },
+          ]}
+        />
+        {source === "file" && (
+          <div className="fr-grid-row fr-grid-row--gutters fr-mt-2w">
+            <div className="fr-col-6">
+              <Input
+                label="Fichier BAL *"
+                nativeInputProps={{
+                  type: "file",
+                  accept: ".csv",
+                  ref: fileInputRef,
+                  onChange: (e) => setFile(e.target.files?.[0] ?? null),
+                }}
+              />
+            </div>
+          </div>
+        )}
+      </section>
+
+      <div className="form-controls">
+        <Button
+          type="submit"
+          iconId="fr-icon-save-line"
+          disabled={
+            isSubmitting ||
+            emails.length === 0 ||
+            (source === "file" && !file)
+          }
+        >
+          {isSubmitting ? "Création en cours…" : "Créer la BAL"}
+        </Button>
+      </div>
+    </StyledForm>
+  );
+};

--- a/lib/api-mes-adresses.ts
+++ b/lib/api-mes-adresses.ts
@@ -1,5 +1,8 @@
 import { Habilitation } from "types/api-depot.types";
-import type { BaseLocaleType } from "../types/mes-adresses";
+import type {
+  BaseLocaleSettingType,
+  BaseLocaleType,
+} from "../types/mes-adresses";
 import type { PageType } from "../types/page";
 
 const NEXT_PUBLIC_API_MES_ADRESSES =
@@ -32,19 +35,36 @@ async function processReponse(res: Response) {
 }
 
 export async function getBaseLocale(
-  baseLocaleId: string
+  baseLocaleId: string,
 ): Promise<BaseLocaleType> {
   const res: Response = await fetch(
-    `${PROXY_MES_ADRESSES_API}/bases-locales/${baseLocaleId}`
+    `${PROXY_MES_ADRESSES_API}/bases-locales/${baseLocaleId}`,
   );
   return processReponse(res);
 }
 
 export async function getBaseLocaleIsHabilitationValid(
-  baseLocaleId: string
+  baseLocaleId: string,
 ): Promise<boolean> {
   const res: Response = await fetch(
-    `${NEXT_PUBLIC_API_MES_ADRESSES}/bases-locales/${baseLocaleId}/habilitation/is-valid`
+    `${NEXT_PUBLIC_API_MES_ADRESSES}/bases-locales/${baseLocaleId}/habilitation/is-valid`,
+  );
+  return processReponse(res);
+}
+
+export async function updateSettingsBaseLocale(
+  baseLocaleId: string,
+  settings: BaseLocaleSettingType,
+) {
+  const res: Response = await fetch(
+    `${PROXY_MES_ADRESSES_API}/bases-locales/${baseLocaleId}`,
+    {
+      method: "PUT",
+      headers: {
+        "content-type": "application/json",
+      },
+      body: JSON.stringify({ settings }),
+    },
   );
   return processReponse(res);
 }
@@ -54,13 +74,13 @@ export async function removeBaseLocale(baseLocaleId: string) {
     `${PROXY_MES_ADRESSES_API}/bases-locales/${baseLocaleId}`,
     {
       method: "DELETE",
-    }
+    },
   );
   return processReponse(res);
 }
 
 export async function searchBasesLocales(
-  query: SearchBasesLocalesParams
+  query: SearchBasesLocalesParams,
 ): Promise<PageType<BaseLocaleType>> {
   const { page = 1, limit = 20, deleted = false } = query;
   const offset = (page - 1) * limit;
@@ -70,7 +90,7 @@ export async function searchBasesLocales(
     .join("&");
 
   const res: Response = await fetch(
-    `${PROXY_MES_ADRESSES_API}/bases-locales/search?${queryString}`
+    `${PROXY_MES_ADRESSES_API}/bases-locales/search?${queryString}`,
   );
   return processReponse(res);
 }
@@ -83,21 +103,21 @@ export async function getStatCreations({
   to: string;
 }) {
   const res = await fetch(
-    `${NEXT_PUBLIC_API_MES_ADRESSES}/stats/bals/creations?from=${from}&to=${to}`
+    `${NEXT_PUBLIC_API_MES_ADRESSES}/stats/bals/creations?from=${from}&to=${to}`,
   );
   return processReponse(res);
 }
 
 export async function createHabilitation(
   balId: string,
-  token: string
+  token: string,
 ): Promise<Habilitation> {
   const res = await fetch(
     `${NEXT_PUBLIC_API_MES_ADRESSES}/bases-locales/${balId}/habilitation`,
     {
       method: "POST",
       headers: { Authorization: `Bearer ${token}` },
-    }
+    },
   );
 
   return processReponse(res);

--- a/lib/api-mes-adresses.ts
+++ b/lib/api-mes-adresses.ts
@@ -108,6 +108,42 @@ export async function getStatCreations({
   return processReponse(res);
 }
 
+export async function createBaseLocale(
+  nom: string,
+  emails: string[],
+  commune: string,
+): Promise<BaseLocaleType> {
+  const res = await fetch(`${PROXY_MES_ADRESSES_API}/bases-locales`, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({ nom, emails, commune }),
+  });
+  return processReponse(res);
+}
+
+export async function populateBaseLocale(
+  balId: string,
+): Promise<BaseLocaleType> {
+  const res = await fetch(
+    `${PROXY_MES_ADRESSES_API}/bases-locales/${balId}/populate`,
+    { method: "POST" },
+  );
+  return processReponse(res);
+}
+
+export async function uploadBALFile(
+  balId: string,
+  file: File,
+): Promise<unknown> {
+  const formData = new FormData();
+  formData.append("file", file);
+  const res = await fetch(
+    `${PROXY_MES_ADRESSES_API}/bases-locales/${balId}/upload`,
+    { method: "POST", body: formData },
+  );
+  return processReponse(res);
+}
+
 export async function createHabilitation(
   balId: string,
   token: string,

--- a/pages/communes/[code].tsx
+++ b/pages/communes/[code].tsx
@@ -237,6 +237,14 @@ const CommuneSource = ({
           otherBalPublishedIgnored:
             !baseLocale.settings?.otherBalPublishedIgnored,
         });
+
+        setBals((bals) =>
+          bals.map((bal) =>
+            bal.id === baseLocale.id
+              ? { ...bal, settings: res.settings }
+              : bal,
+          ),
+        );
         toast("La Bal a bien été modifiée", { type: "success" });
       } catch (e: unknown) {
         console.error(e);
@@ -245,7 +253,7 @@ const CommuneSource = ({
         }
       }
     },
-    [],
+    [setBals],
   );
 
   const actionsBals = {

--- a/pages/communes/[code].tsx
+++ b/pages/communes/[code].tsx
@@ -14,12 +14,12 @@ import type { BaseLocaleType } from "../../types/mes-adresses";
 import { getCommune, isCommune } from "@/lib/cog";
 
 import { ModalAlert } from "@/components/modal-alerte";
+import { getAllRevisionByCommune, getEmailsCommune } from "@/lib/api-depot";
 import {
-  getAllRevisionByCommune,
-  getClients,
-  getEmailsCommune,
-} from "@/lib/api-depot";
-import { searchBasesLocales, removeBaseLocale } from "@/lib/api-mes-adresses";
+  searchBasesLocales,
+  removeBaseLocale,
+  updateSettingsBaseLocale,
+} from "@/lib/api-mes-adresses";
 import { getRevisionsByCommune } from "@/lib/api-moissonneur-bal";
 
 import { EditableList } from "@/components/editable-list";
@@ -135,7 +135,6 @@ const CommuneSource = ({
       page: page.current,
       limit: page.limit,
     });
-
     setBals(res.results);
     setPageMesAdresses({
       ...page,
@@ -159,7 +158,7 @@ const CommuneSource = ({
         await getRevisionsByCommune(code);
 
       setInitialRevisionsMoissonneur(
-        sortBy(initialRevisionsMoissonneur, "createdAt").reverse()
+        sortBy(initialRevisionsMoissonneur, "createdAt").reverse(),
       );
       setPageMoissonneur((pageMoissonneur) => ({
         ...pageMoissonneur,
@@ -191,7 +190,7 @@ const CommuneSource = ({
             ...r.client,
             sourceName:
               sourcesMoissonneur.find(
-                (s) => s.id === r.context?.extras?.sourceId
+                (s) => s.id === r.context?.extras?.sourceId,
               )?.title || "inconnu",
           },
         };
@@ -230,9 +229,31 @@ const CommuneSource = ({
     }
   }, [balToDeleted, code, fetchBals, setBalToDeleted, pageMesAdresses]);
 
+  const setOtherBalPublishedIgnored = useCallback(
+    async (baseLocale: BaseLocaleType) => {
+      try {
+        const res = await updateSettingsBaseLocale(baseLocale.id, {
+          ...baseLocale.settings,
+          otherBalPublishedIgnored:
+            !baseLocale.settings?.otherBalPublishedIgnored,
+        });
+        toast("La Bal a bien été modifiée", { type: "success" });
+      } catch (e: unknown) {
+        console.error(e);
+        if (e instanceof Error) {
+          toast(e.message, { type: "error" });
+        }
+      }
+    },
+    [],
+  );
+
   const actionsBals = {
     delete(item: BaseLocaleType) {
       setBalToDeleted(item);
+    },
+    toggleOtherBalPublishedIgnored(item: BaseLocaleType) {
+      setOtherBalPublishedIgnored(item);
     },
     select(item: BaseLocaleType) {
       if (balSelected === item.id) {
@@ -288,6 +309,7 @@ const CommuneSource = ({
           "Date mise à jour",
           "Emails",
           "Nombre numéros / certifiés",
+          "Editable",
           "Actions",
         ]}
         caption="Bals mes adresses"
@@ -332,19 +354,19 @@ export async function getServerSideProps({ params }) {
   const signalementCommuneSettings = await getSignalementCommuneSettings(code);
   const pendingSignalementCount = await getSignalementCount(
     code,
-    SignalementStatusEnum.PENDING
+    SignalementStatusEnum.PENDING,
   );
   const processedSignalementCount = await getSignalementCount(
     code,
-    SignalementStatusEnum.PROCESSED
+    SignalementStatusEnum.PROCESSED,
   );
   const ignoredSignalementCount = await getSignalementCount(
     code,
-    SignalementStatusEnum.IGNORED
+    SignalementStatusEnum.IGNORED,
   );
   const expiredSignalementCount = await getSignalementCount(
     code,
-    SignalementStatusEnum.EXPIRED
+    SignalementStatusEnum.EXPIRED,
   );
 
   const alerts = [];

--- a/pages/communes/[code]/index.tsx
+++ b/pages/communes/[code]/index.tsx
@@ -1,16 +1,18 @@
 import { useState, useEffect, useMemo, useCallback } from "react";
+import Link from "next/link";
 import { toast } from "react-toastify";
 import { sortBy } from "lodash";
+import { Button } from "@codegouvfr/react-dsfr/Button";
 
 import type {
   RevisionMoissoneurType,
   SourceMoissoneurType,
-} from "../../types/moissoneur";
+} from "types/moissoneur";
 import type {
   Client,
   Revision as RevisionApiDepot,
-} from "../../types/api-depot.types";
-import type { BaseLocaleType } from "../../types/mes-adresses";
+} from "types/api-depot.types";
+import type { BaseLocaleType } from "types/mes-adresses";
 import { getCommune, isCommune } from "@/lib/cog";
 
 import { ModalAlert } from "@/components/modal-alerte";
@@ -240,9 +242,7 @@ const CommuneSource = ({
 
         setBals((bals) =>
           bals.map((bal) =>
-            bal.id === baseLocale.id
-              ? { ...bal, settings: res.settings }
-              : bal,
+            bal.id === baseLocale.id ? { ...bal, settings: res.settings } : bal,
           ),
         );
         toast("La Bal a bien été modifiée", { type: "success" });
@@ -326,6 +326,13 @@ const CommuneSource = ({
         page={{ ...pageMesAdresses, onPageChange: onPageMesAdressesChange }}
         actions={actionsBals}
         selectedItem={balSelected}
+        createBtn={
+          <Link href={`/communes/${code}/new`} passHref legacyBehavior>
+            <Button iconId="fr-icon-add-line" className="fr-mb-2w">
+              Nouvelle BAL
+            </Button>
+          </Link>
+        }
       />
       <EditableList
         headers={["Source", "Date", "Nb lignes / erreurs", "Status"]}

--- a/pages/communes/[code]/index.tsx
+++ b/pages/communes/[code]/index.tsx
@@ -337,7 +337,7 @@ const CommuneSource = ({
       />
       <EditableList
         headers={["Source", "Date", "Nb lignes / erreurs", "Status"]}
-        caption="Révisions Moissoneur"
+        caption="Révisions Moissonneur"
         data={revisionsMoissoneur}
         renderItem={RevisionItemMoissoneur}
         page={{ ...pageMoissonneur, onPageChange: onPageMoissonneurChange }}

--- a/pages/communes/[code]/new.tsx
+++ b/pages/communes/[code]/new.tsx
@@ -5,6 +5,7 @@ import { NewBalForm } from "@/components/communes/new-bal-form";
 import {
   createBaseLocale,
   populateBaseLocale,
+  updateSettingsBaseLocale,
   uploadBALFile,
 } from "@/lib/api-mes-adresses";
 
@@ -25,6 +26,10 @@ const NewBalPage = () => {
       } else if (source === "ban") {
         await populateBaseLocale(newBal.id);
       }
+      await updateSettingsBaseLocale(newBal.id, {
+        ...newBal.settings,
+        otherBalPublishedIgnored: true,
+      });
       toast("BAL créée avec succès", { type: "success" });
       await router.push(`/communes/${code}`);
     } catch (e: unknown) {

--- a/pages/communes/[code]/new.tsx
+++ b/pages/communes/[code]/new.tsx
@@ -1,0 +1,46 @@
+import { useRouter } from "next/router";
+import { toast } from "react-toastify";
+
+import { NewBalForm } from "@/components/communes/new-bal-form";
+import {
+  createBaseLocale,
+  populateBaseLocale,
+  uploadBALFile,
+} from "@/lib/api-mes-adresses";
+
+const NewBalPage = () => {
+  const router = useRouter();
+  const { code } = router.query as { code: string };
+
+  const handleCreate = async (
+    nom: string,
+    emails: string[],
+    source: "ban" | "file",
+    file: File | null,
+  ) => {
+    try {
+      const newBal = await createBaseLocale(nom, emails, code);
+      if (source === "file" && file) {
+        await uploadBALFile(newBal.id, file);
+      } else if (source === "ban") {
+        await populateBaseLocale(newBal.id);
+      }
+      toast("BAL créée avec succès", { type: "success" });
+      await router.push(`/communes/${code}`);
+    } catch (e: unknown) {
+      console.error(e);
+      if (e instanceof Error) {
+        toast(e.message, { type: "error" });
+      }
+    }
+  };
+
+  return (
+    <div className="fr-container fr-my-4w">
+      <h1>Nouvelle BAL</h1>
+      {code && <NewBalForm codeCommune={code} onSubmit={handleCreate} />}
+    </div>
+  );
+};
+
+export default NewBalPage;

--- a/server/proxy/mes-adresses-api.proxy.ts
+++ b/server/proxy/mes-adresses-api.proxy.ts
@@ -49,6 +49,30 @@ async function removeBal(req, res) {
   forward(response, res);
 }
 
+async function createBal(req, res) {
+  const response = await client.post("bases-locales", { json: req.body });
+  forward(response, res);
+}
+
+async function populateBal(req, res) {
+  const response = await client.post(
+    `bases-locales/${req.params.baseLocaleId}/populate`,
+    { json: {} },
+  );
+  forward(response, res);
+}
+
+async function uploadFile(req, res) {
+  const response = await client.post(
+    `bases-locales/${req.params.baseLocaleId}/upload`,
+    {
+      body: req,
+      headers: { "content-type": req.headers["content-type"] },
+    },
+  );
+  forward(response, res);
+}
+
 const app = express.Router();
 
 app.use(express.json());
@@ -56,6 +80,9 @@ app.use(cors());
 
 app.get("/bases-locales/search", w(searchBal));
 app.get("/bases-locales/:baseLocaleId", w(getBal));
+app.post("/bases-locales", w(createBal));
+app.post("/bases-locales/:baseLocaleId/populate", w(populateBal));
+app.post("/bases-locales/:baseLocaleId/upload", w(uploadFile));
 app.put("/bases-locales/:baseLocaleId", w(updateSettingBal));
 app.delete("/bases-locales/:baseLocaleId", w(removeBal));
 

--- a/server/proxy/mes-adresses-api.proxy.ts
+++ b/server/proxy/mes-adresses-api.proxy.ts
@@ -34,9 +34,17 @@ async function searchBal(req, res) {
   forward(response, res);
 }
 
+async function updateSettingBal(req, res) {
+  const response = await client.put(
+    `bases-locales/${req.params.baseLocaleId}`,
+    { json: req.body },
+  );
+  forward(response, res);
+}
+
 async function removeBal(req, res) {
   const response = await client.delete(
-    `bases-locales/${req.params.baseLocaleId}`
+    `bases-locales/${req.params.baseLocaleId}`,
   );
   forward(response, res);
 }
@@ -48,6 +56,7 @@ app.use(cors());
 
 app.get("/bases-locales/search", w(searchBal));
 app.get("/bases-locales/:baseLocaleId", w(getBal));
+app.put("/bases-locales/:baseLocaleId", w(updateSettingBal));
 app.delete("/bases-locales/:baseLocaleId", w(removeBal));
 
 export default app;

--- a/types/mes-adresses.ts
+++ b/types/mes-adresses.ts
@@ -18,6 +18,14 @@ export type SyncType = {
   lastUploadedRevisionId: string;
 };
 
+export class BaseLocaleSettingType {
+  otherBalPublishedIgnored?: boolean;
+  languageGoalIgnored?: boolean;
+  toponymeGoalIgnored?: boolean;
+  fondsDeCartes?: any[];
+  ignoredAlertCodes?: string[];
+}
+
 export type BaseLocaleType = {
   id: string;
   token?: string;
@@ -32,4 +40,5 @@ export type BaseLocaleType = {
   createdAt?: string;
   updatedAt?: string;
   deletedAt?: string;
+  settings: BaseLocaleSettingType;
 };


### PR DESCRIPTION
## CONTEXT

Dans le cadre on l'on bloque la création et l'édition de BAL en brouillon lorsqu'une BAL est déjà publié, il faut pouvoir:

- Authoriser les commune a éditer un brouillon (même si une BAL est déjà publier)

<img width="1585" height="510" alt="Capture d’écran 2026-04-13 à 15 02 33" src="https://github.com/user-attachments/assets/3469dfe3-29c3-4fe2-86cf-03c01df4a581" />

- Créer une BAL depuis BAL-admin

<img width="987" height="831" alt="Capture d’écran 2026-04-13 à 14 56 32" src="https://github.com/user-attachments/assets/dc14b096-b390-4c0e-8513-68c61832f996" />

## PR

- [ ] https://github.com/BaseAdresseNationale/mes-adresses/pull/1106
- [ ] https://github.com/BaseAdresseNationale/mes-adresses/pull/1105
- [ ] https://github.com/BaseAdresseNationale/mes-adresses-api/pull/570