### PR TITLE
feat: add import type bals

### DIFF
--- a/components/communes/bals-item.tsx
+++ b/components/communes/bals-item.tsx
@@ -2,14 +2,14 @@ import Link from "next/link";
 import { Badge } from "@codegouvfr/react-dsfr/Badge";
 import { Button } from "@codegouvfr/react-dsfr/Button";
 
-import type { BaseLocaleType } from "../../types/mes-adresses";
+import { BaseLocaleType, ImportTypeEnum } from "../../types/mes-adresses";
 import { computeStatus } from "@/lib/bal-status";
 import { formatDate } from "@/lib/util/date";
 
 export const BalsItem = (
   item: BaseLocaleType,
   actions: Record<string, (item: BaseLocaleType) => void>,
-  selectedItem?: string
+  selectedItem?: string,
 ) => {
   const {
     id,
@@ -21,9 +21,20 @@ export const BalsItem = (
     updatedAt,
     nbNumeros,
     nbNumerosCertifies,
+    importType,
   } = item;
 
   const computedStatus = computeStatus(status, sync);
+  const getSeverityImport = () => {
+    if (importType === ImportTypeEnum.API_DEPOT) {
+      return "success";
+    } else if (importType === ImportTypeEnum.BAN) {
+      return "info";
+    } else if (importType === ImportTypeEnum.CSV) {
+      return "new";
+    }
+    return "warning";
+  };
 
   return (
     <tr key={id}>
@@ -35,16 +46,21 @@ export const BalsItem = (
         </Badge>
       </td>
       <td className="fr-col fr-my-1v">
-        {createdAt ? formatDate(createdAt) : "inconnu"}
+        {createdAt ? formatDate(createdAt, "Pp") : "inconnu"}
       </td>
       <td className="fr-col fr-my-1v">
-        {updatedAt ? formatDate(updatedAt) : "inconnu"}
+        {updatedAt ? formatDate(updatedAt, "Pp") : "inconnu"}
       </td>
       <td className="fr-col fr-my-1v">
         {emails ? emails.join("\n") : "inconnu"}
       </td>
       <td className="fr-col fr-my-1v">
         {nbNumeros} / {nbNumerosCertifies}
+      </td>
+      <td className="fr-col fr-my-1v">
+        <Badge severity={getSeverityImport()} noIcon>
+          {importType || "Inconnu"}
+        </Badge>
       </td>
       <td className="fr-col fr-my-1v">
         <div style={{ width: "150px" }}>

--- a/pages/communes/[code].tsx
+++ b/pages/communes/[code].tsx
@@ -159,7 +159,7 @@ const CommuneSource = ({
         await getRevisionsByCommune(code);
 
       setInitialRevisionsMoissonneur(
-        sortBy(initialRevisionsMoissonneur, "createdAt").reverse()
+        sortBy(initialRevisionsMoissonneur, "createdAt").reverse(),
       );
       setPageMoissonneur((pageMoissonneur) => ({
         ...pageMoissonneur,
@@ -191,7 +191,7 @@ const CommuneSource = ({
             ...r.client,
             sourceName:
               sourcesMoissonneur.find(
-                (s) => s.id === r.context?.extras?.sourceId
+                (s) => s.id === r.context?.extras?.sourceId,
               )?.title || "inconnu",
           },
         };
@@ -288,6 +288,7 @@ const CommuneSource = ({
           "Date mise à jour",
           "Emails",
           "Nombre numéros / certifiés",
+          "Import",
           "Actions",
         ]}
         caption="Bals mes adresses"
@@ -332,19 +333,19 @@ export async function getServerSideProps({ params }) {
   const signalementCommuneSettings = await getSignalementCommuneSettings(code);
   const pendingSignalementCount = await getSignalementCount(
     code,
-    SignalementStatusEnum.PENDING
+    SignalementStatusEnum.PENDING,
   );
   const processedSignalementCount = await getSignalementCount(
     code,
-    SignalementStatusEnum.PROCESSED
+    SignalementStatusEnum.PROCESSED,
   );
   const ignoredSignalementCount = await getSignalementCount(
     code,
-    SignalementStatusEnum.IGNORED
+    SignalementStatusEnum.IGNORED,
   );
   const expiredSignalementCount = await getSignalementCount(
     code,
-    SignalementStatusEnum.EXPIRED
+    SignalementStatusEnum.EXPIRED,
   );
 
   const alerts = [];

--- a/types/mes-adresses.ts
+++ b/types/mes-adresses.ts
@@ -11,6 +11,12 @@ export enum StatusSyncEnum {
   CONFLICT = "conflict",
 }
 
+export enum ImportTypeEnum {
+  API_DEPOT = "api-depot",
+  BAN = "ban",
+  CSV = "csv",
+}
+
 export type SyncType = {
   status: StatusSyncEnum;
   isPaused: boolean;
@@ -24,6 +30,7 @@ export type BaseLocaleType = {
   nom?: string;
   status?: StatusBaseLocalEnum;
   commune?: string;
+  importType: ImportTypeEnum;
   nbNumeros?: number;
   nbNumerosCertifies?: number;
   isAllCertified?: boolean;


### PR DESCRIPTION
## CONTEXT

Maintenant qu'on sauvegarde le type d'import des bals dans mes-adresses, on peut l'afficher dans la page communes dans la liste des bals mes-adresses

<img width="1575" height="585" alt="Capture d’écran 2026-04-13 à 15 29 55" src="https://github.com/user-attachments/assets/87df4a6d-340a-4908-87e1-83400ec043e3" />
